### PR TITLE
[NAT-322] Change Userservice getSessionToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - SDKContract method to get active user session token
 ### Changed
+- User service getSessionToken method now returns with an active token not the last known.
 ### Removed
 ### Fixed
 ### Updated

--- a/sdk-core/src/main/java/care/data4life/sdk/UserService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/UserService.kt
@@ -65,7 +65,7 @@ internal class UserService(private val alias: String,
     }
 
     fun getSessionToken(alias: String): Single<String> {
-        return Single.fromCallable { oAuthService.getAccessToken(alias) }
+        return Single.fromCallable { oAuthService.refreshAccessToken(alias) }
     }
 
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/UserServiceTest.java
+++ b/sdk-core/src/test/java/care/data4life/sdk/UserServiceTest.java
@@ -108,7 +108,7 @@ public class UserServiceTest {
     @Test
     public void getSessionToken_shouldReturnTrue() throws Exception {
         // given
-        when(oAuthService.getAccessToken(USER_ALIAS)).thenReturn(AUTH_TOKEN);
+        when(oAuthService.refreshAccessToken(USER_ALIAS)).thenReturn(AUTH_TOKEN);
 
         // when
         TestObserver<String> testSubscriber = userService.getSessionToken(USER_ALIAS)
@@ -123,7 +123,7 @@ public class UserServiceTest {
     @Test
     public void getSessionToken_shouldThrowError() throws Exception {
         // given
-        when(oAuthService.getAccessToken(USER_ALIAS)).thenReturn(null);
+        when(oAuthService.refreshAccessToken(USER_ALIAS)).thenReturn(null);
 
         // when
         TestObserver<String> testSubscriber = userService.getSessionToken(USER_ALIAS)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the client requests a session token from the SDK but there were no network calls for a while the SDK returns with an expired session token.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
Changed the implementation to call the `refreshAccessToken` when returning the session token to ensure providing an active token.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
