### PR TITLE
Fix checkRestrictions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ toc::[]
 === Removed
 
 === Fixed
+* RecordService#checkDataRestrictions for Resources with unextractable Attachments
 
 * missing Task in SDKContract for some of the operations
 

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -810,9 +810,7 @@ class RecordService(
         val resource = record.resource
 
         if (!fhirAttachmentHelper.hasAttachment(resource)) return record
-        val attachments = fhirAttachmentHelper.getAttachment(resource) as List<Any?>?
-
-        attachments ?: return record
+        val attachments = fhirAttachmentHelper.getAttachment(resource) as List<Any?>? ?: return record
 
         if (record.attachmentsKey == null) {
             record.attachmentsKey = cryptoService.generateGCKey().blockingGet()
@@ -1128,7 +1126,8 @@ class RecordService(
     @Throws(DataRestrictionException.MaxDataSizeViolation::class, DataRestrictionException.UnsupportedFileType::class)
     fun <T : Any> checkDataRestrictions(resource: T?) {
         if (isFhir(resource) && fhirAttachmentHelper.hasAttachment(resource!!)) {
-            val attachments = fhirAttachmentHelper.getAttachment(resource) as List<Any?>
+            val attachments = fhirAttachmentHelper.getAttachment(resource) as List<Any?>? ?: return
+
             for (rawAttachment in attachments) {
                 rawAttachment ?: return
 

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
@@ -63,11 +63,15 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.internal.Classes.getClass
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
+import java.io.File
 import java.io.IOException
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 class RecordServiceTest : RecordServiceTestBase() {
 
@@ -80,6 +84,10 @@ class RecordServiceTest : RecordServiceTestBase() {
     fun tearDown() {
         stop()
     }
+
+    private fun getResource(
+            resourceName: String
+    ): String = this::class.java.getResource(resourceName).readText(StandardCharsets.UTF_8)
 
     //region utility methods
     @Test
@@ -829,64 +837,7 @@ class RecordServiceTest : RecordServiceTestBase() {
     @Throws(DataRestrictionException.UnsupportedFileType::class, DataRestrictionException.MaxDataSizeViolation::class)
     fun `Given, checkDataRestrictions is called, with a Resource, which has non extractable Attachments, it returns without a failure`() {
         // Given
-        val resourceStr = "{\n" +
-                "    \"resourceType\": \"Patient\",\n" +
-                "    \"id\": \"s4h-patient-example\",\n" +
-                "    \"meta\": {\n" +
-                "        \"profile\": [\n" +
-                "            \"http://fhir.smart4health.eu/StructureDefinition/s4h-patient\"\n" +
-                "        ]\n" +
-                "    },\n" +
-                "    \"name\": [{\n" +
-                "        \"text\": \"Marie Lux-Brennard\",\n" +
-                "        \"family\": \"Lux-Brennard\",\n" +
-                "        \"given\": [\n" +
-                "            \"Marie\"\n" +
-                "        ]\n" +
-                "    }],\n" +
-                "    \"telecom\": [{\n" +
-                "            \"system\": \"phone\",\n" +
-                "            \"value\": \"123-456-789\",\n" +
-                "            \"use\": \"home\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "            \"system\": \"email\",\n" +
-                "            \"value\": \"malubr@example.com\"\n" +
-                "        }\n" +
-                "    ],\n" +
-                "    \"gender\": \"female\",\n" +
-                "    \"birthDate\": \"1998-04-17\",\n" +
-                "    \"address\": [{\n" +
-                "        \"use\": \"home\",\n" +
-                "        \"line\": [\n" +
-                "            \"Beispielstr. 17\"\n" +
-                "        ],\n" +
-                "        \"city\": \"Bärstadt\",\n" +
-                "        \"postalCode\": \"12345\",\n" +
-                "        \"country\": \"Germany\"\n" +
-                "    }],\n" +
-                "    \"contact\": [{\n" +
-                "        \"relationship\": [{\n" +
-                "            \"coding\": [{\n" +
-                "                \"system\": \"http://terminology.hl7.org/CodeSystem/v3-RoleCode\",\n" +
-                "                \"code\": \"MTH\",\n" +
-                "                \"display\": \"Mother\"\n" +
-                "            }]\n" +
-                "        }],\n" +
-                "        \"name\": {\n" +
-                "            \"text\": \"Annabel Lux-Brennard\",\n" +
-                "            \"family\": \"Lux-Brennard\",\n" +
-                "            \"given\": [\n" +
-                "                \"Annabel\"\n" +
-                "            ]\n" +
-                "        },\n" +
-                "        \"telecom\": [{\n" +
-                "            \"system\": \"phone\",\n" +
-                "            \"value\": \"987-654-321\",\n" +
-                "            \"use\": \"home\"\n" +
-                "        }]\n" +
-                "    }]\n" +
-                "}"
+        val resourceStr = getResource("/fhir4/s4h-patient-example.patient.json")
 
         val doc = FhirR4Parser().toFhir(Fhir4Patient::class.java, resourceStr)
 

--- a/sdk-core/src/test/resources/fhir4/s4h-patient-example.patient.json
+++ b/sdk-core/src/test/resources/fhir4/s4h-patient-example.patient.json
@@ -1,0 +1,58 @@
+{
+  "resourceType": "Patient",
+  "id": "s4h-patient-example",
+  "meta": {
+    "profile": [
+      "http://fhir.smart4health.eu/StructureDefinition/s4h-patient"
+    ]
+  },
+  "name": [{
+    "text": "Marie Lux-Brennard",
+    "family": "Lux-Brennard",
+    "given": [
+      "Marie"
+    ]
+  }],
+  "telecom": [{
+    "system": "phone",
+    "value": "123-456-789",
+    "use": "home"
+  },
+    {
+      "system": "email",
+      "value": "malubr@example.com"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1998-04-17",
+  "address": [{
+    "use": "home",
+    "line": [
+      "Beispielstr. 17"
+    ],
+    "city": "Bärstadt",
+    "postalCode": "12345",
+    "country": "Germany"
+  }],
+  "contact": [{
+    "relationship": [{
+      "coding": [{
+        "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+        "code": "MTH",
+        "display": "Mother"
+      }]
+    }],
+    "name": {
+      "text": "Annabel Lux-Brennard",
+      "family": "Lux-Brennard",
+      "given": [
+        "Annabel"
+      ]
+    },
+    "telecom": [{
+      "system": "phone",
+      "value": "987-654-321",
+      "use": "home"
+    }]
+  }]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This addresses the issue, which had been experienced with the [Patient testset](https://github.com/gesundheitscloud/s4h-fhir-profiles/blob/94c4afe43e60bf5c8c4faa5c67276d9ce533789f/examples/s4h-patient-example.patient.json#L1).

## Motivation and Context
The current implementation for `checkDataRestrictions` breaks if a Resource contains Attachments (or at least seen by the FhirAttachmentHelper as such), which are not extractible out of the Resource.

## How is it being implemented?
The Attachements are not longer referenced as List, there are now nullable. Additionally after the extraction of the Attachments is now a null check and if the Attachments are null `checkDataRestrictions` simply returns.
Also to avoid any confusion the style of `_uploadData` and `checkDataRestrictions` had been aligned.

## How Has This Been Tested?
A new Unittest had been added, which makes use of the [Patient testset](https://github.com/gesundheitscloud/s4h-fhir-profiles/blob/94c4afe43e60bf5c8c4faa5c67276d9ce533789f/examples/s4h-patient-example.patient.json#L1), which breaks the current SDK.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
