### PR TITLE
Change RecordService#countRecords tests

### DIFF
--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
         exclude(group = "care.data4life.hc-fhir-sdk-java", module = "hc-fhir-sdk-java")
     }
     testImplementation(Dependencies.Java.Test.junit)
+    testImplementation(Dependencies.Java.Test.kotlinTest)
 
     testImplementation(Dependencies.Java.Test.mockitoInline)
     testImplementation(Dependencies.Java.Test.truth)

--- a/sdk-core/src/main/java/care/data4life/sdk/fhir/FhirContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/fhir/FhirContract.kt
@@ -18,7 +18,8 @@ package care.data4life.sdk.fhir
 
 import care.data4life.crypto.GCKey
 
-internal interface FhirContract {
+//TODO: make internal
+interface FhirContract {
 
     interface Service {
         fun _encryptResource(dataKey: GCKey, resource: Any): String


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This refactors the test set for RecordService#countRecords. It also make some minor changes on the surface of the RecordService.

## Motivation and Context
Currently the tests of the SDK are not in a good shape. Also in the long run there is the need to replace mockito since it is troublesome in regards of non nullable parameters.
At last the performance of the tests is bad, which needs to be improved.

## How is it being implemented?
kotlin-test is now hooked up in the tests setup to enable more readable failure test.
Also some properties of the RecordService are now pointing to interfaces instead of objects and a typo has been fixed.
However the main focus is the test set of RecordService#countRecords which uses now mockk instead of mockito.

## How Has This Been Tested?
Since this is about tests, no further test sets are needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
