### PR TITLE
[NAT-532] RecordService uses the UserId instead of RecordId in the legacy batch methods deleteRecords and fetchRecords

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ toc::[]
 * `EncryptedRecord`, `EncryptedKey`, `EncryptedKeyTypeAdapter` to Kotlin
 * CryptoService#encryptString -> CryptoService#encryptAndEncodeString
 * CryptoService#decryptString -> CryptoService#decodeAndDecryptString
+* RecordService#deleteRecord invocation had mixed user and resource id.
 
 === Removed
 * RxJava from TagEncryptionService

--- a/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
+++ b/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
@@ -125,7 +125,7 @@ public class LegacyDataClient implements SdkContract.LegacyDataClient {
     @Override
     public void deleteRecord(String recordId, Callback listener) {
         Completable operation = userService.getUID()
-                .flatMapCompletable(uid -> recordService.deleteRecord(recordId, uid));
+                .flatMapCompletable(uid -> recordService.deleteRecord(uid, recordId));
         handler.executeCompletable(operation, listener);
     }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -200,7 +200,7 @@ class RecordService(
                 .fromCallable { recordIds }
                 .flatMapIterable { it }
                 .flatMapSingle { recordId ->
-                    deleteRecord(recordId, userId)
+                    deleteRecord(userId, recordId)
                             .doOnError { error ->
                                 failedDeletes.add(
                                         Pair(recordId, errorHandler.handleError(error)))

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
@@ -908,7 +908,7 @@ class RecordServiceTest : RecordServiceTestBase() {
     @Throws(InterruptedException::class)
     fun deleteRecords_shouldDeleteRecords() {
         // Given
-        Mockito.doReturn(Completable.complete()).`when`(recordService).deleteRecord(RECORD_ID, USER_ID)
+        Mockito.doReturn(Completable.complete()).`when`(recordService).deleteRecord(USER_ID, RECORD_ID)
         val ids = listOf(RECORD_ID, RECORD_ID)
 
         // When
@@ -923,7 +923,7 @@ class RecordServiceTest : RecordServiceTestBase() {
         Truth.assertThat(result.failedDeletes).hasSize(0)
         Truth.assertThat(result.successfulDeletes).hasSize(2)
         inOrder.verify(recordService).deleteRecords(ids, USER_ID)
-        inOrder.verify(recordService, Mockito.times(2)).deleteRecord(RECORD_ID, USER_ID)
+        inOrder.verify(recordService, Mockito.times(2)).deleteRecord(USER_ID, RECORD_ID)
         inOrder.verifyNoMoreInteractions()
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the legacy batch methods deleteRecords and fetchRecords delegate their parameters in the wrong order to the underlying calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR only fixed the `deleteRecord` calls.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
Fix RecordService#deleteRecords parameter problem.
Fix LegacyDataClient#deleteRecord parameter problem.
Modified the wrong test.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
