### PR TITLE
[NAT-532] Fix RecordService#fetchRecords (legacy)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,7 @@ toc::[]
 
 === Fixed
 * RecordService#deleteRecord invocation had mixed user and resource id.
+* RecordService#fetchRecords invocation had mixed user and resource id.
 
 === Bumped
 

--- a/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
+++ b/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
@@ -157,7 +157,7 @@ public class LegacyDataClient implements SdkContract.LegacyDataClient {
     @Override
     public <T extends DomainResource> Task fetchRecord(String recordId, ResultListener<Record<T>> listener) {
         Single<Record<T>> operation = userService.getUID()
-                .flatMap(uid -> recordService.fetchFhir3Record(recordId, uid));
+                .flatMap(uid -> recordService.fetchFhir3Record(uid, recordId));
         return handler.executeSingle(operation, listener);
     }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -1187,7 +1187,7 @@ class RecordService(
         const val FULL_ATTACHMENT_ID_POS = 1
         const val PREVIEW_ID_POS = 2
         const val THUMBNAIL_ID_POS = 3
-        // ToDo refactor
+        // TODO refactor
         private val DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT, Locale.US)
         private val DATE_TIME_FORMATTER = DateTimeFormatterBuilder()
                 .parseLenient()

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -220,9 +220,9 @@ class RecordService(
     ): Single<BaseRecord<T>> {
         return apiService
                 .fetchRecord(alias, userId, recordId)
-                .map { decryptRecord<T>(it, userId) }
-                .map { assignResourceId(it) }
-                .map { recordFactory.getInstance(it) }
+                .map { encryptedRecord -> decryptRecord<T>(encryptedRecord, userId) }
+                .map { decryptedRecord -> assignResourceId(decryptedRecord) }
+                .map { decryptedRecord -> recordFactory.getInstance(decryptedRecord) }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -250,10 +250,12 @@ class RecordService(
                 .fromCallable { recordIds }
                 .flatMapIterable { it }
                 .flatMapSingle { recordId ->
-                    fetchFhir3Record<T>(recordId, userId)
-                            .ignoreErrors {
-                                failedFetches.add(Pair(recordId, errorHandler.handleError(it)))
-                            }
+                    fetchFhir3Record<T>(
+                            userId = userId,
+                            recordId = recordId
+                    ).ignoreErrors {
+                        failedFetches.add(Pair(recordId, errorHandler.handleError(it)))
+                    }
                 }
                 .toList()
                 .map { FetchResult(it, failedFetches) }
@@ -280,25 +282,25 @@ class RecordService(
             pageSize: Int,
             offset: Int
     ): Single<List<BaseRecord<T>>> {
-        val startTime = if (startDate != null) DATE_FORMATTER.format(startDate) else null
-        val endTime = if (endDate != null) DATE_FORMATTER.format(endDate) else null
+        val startTime = if (startDate != null) formatDate(startDate) else null
+        val endTime = if (endDate != null) formatDate(endDate) else null
 
         return Observable
                 .fromCallable { taggingService.getTagFromType(resourceType as Class<Any>?) }
                 .map { plainTags -> encryptTagsAndAnnotations(plainTags, annotations) }
                 .flatMap {
-                    apiService.fetchRecords(
+                    encryptedTags -> apiService.fetchRecords(
                             alias,
                             userId,
                             startTime,
                             endTime,
                             pageSize,
                             offset,
-                            it
+                            encryptedTags
                     )
                 }
                 .flatMapIterable { it }
-                .map { decryptRecord<T>(it, userId) }
+                .map { encryptedRecord -> decryptRecord<T>(encryptedRecord, userId) }
                 .let {
                     if (resourceType == null) {
                         it
@@ -306,8 +308,8 @@ class RecordService(
                         it.filter { decryptedRecord -> resourceType.isAssignableFrom(decryptedRecord.resource::class.java) }
                     }.filter { decryptedRecord -> decryptedRecord.annotations.containsAll(annotations) }
                 }
-                .map { assignResourceId(it) }
-                .map { recordFactory.getInstance(it) }
+                .map { decryptedRecord -> assignResourceId(decryptedRecord) }
+                .map { decryptedRecord -> recordFactory.getInstance(decryptedRecord) }
                 .toList() as Single<List<BaseRecord<T>>>
     }
 
@@ -1185,11 +1187,13 @@ class RecordService(
         const val FULL_ATTACHMENT_ID_POS = 1
         const val PREVIEW_ID_POS = 2
         const val THUMBNAIL_ID_POS = 3
+        // ToDo refactor
         private val DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT, Locale.US)
         private val DATE_TIME_FORMATTER = DateTimeFormatterBuilder()
                 .parseLenient()
                 .appendPattern(DATE_TIME_FORMAT)
                 .toFormatter(Locale.US)
         private val UTC_ZONE_ID = ZoneId.of("UTC")
+        internal fun formatDate(dateTime: LocalDate): String = DATE_FORMAT.format(dateTime)
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
@@ -16,40 +16,93 @@
 
 package care.data4life.sdk
 
-import care.data4life.fhir.stu3.model.CarePlan
-import care.data4life.fhir.stu3.model.DomainResource
+import care.data4life.fhir.stu3.model.CarePlan as Fhir3CarePlan
+import care.data4life.fhir.r4.model.CarePlan as Fhir4CarePlan
+import care.data4life.sdk.RecordServiceTestBase.Companion.ALIAS
+import care.data4life.sdk.RecordServiceTestBase.Companion.PARTNER_ID
+import care.data4life.sdk.RecordServiceTestBase.Companion.RECORD_ID
+import care.data4life.sdk.RecordServiceTestBase.Companion.USER_ID
+import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.call.DataRecord
 import care.data4life.sdk.call.Fhir4Record
 import care.data4life.sdk.data.DataResource
 import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
+import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.lang.DataValidationException
 import care.data4life.sdk.model.Record
 import care.data4life.sdk.model.RecordMapper
 import care.data4life.sdk.model.definitions.BaseRecord
-import com.google.common.truth.Truth
+import care.data4life.sdk.network.model.DecryptedDataRecord
+import care.data4life.sdk.network.model.EncryptedRecord
+import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
+import care.data4life.sdk.network.model.definitions.DecryptedFhir3Record
+import care.data4life.sdk.network.model.definitions.DecryptedFhir4Record
+import care.data4life.sdk.tag.TaggingContract
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.spyk
+import io.mockk.unmockkObject
+import io.mockk.verify
 import io.reactivex.Observable
 import io.reactivex.Single
 import org.junit.After
-import org.junit.Assert.assertSame
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito
 import org.threeten.bp.LocalDate
 import java.io.IOException
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
-class RecordServiceFetchRecordsTest : RecordServiceTestBase() {
+class RecordServiceFetchRecordsTest {
+    private lateinit var recordService: RecordService
+    private lateinit var apiService: ApiService
+    private lateinit var cryptoService: CryptoService
+    private lateinit var fhirService: FhirContract.Service
+    private lateinit var tagEncryptionService: TaggingContract.EncryptionService
+    private lateinit var taggingService: TaggingContract.Service
+    private lateinit var attachmentService: AttachmentContract.Service
+    private lateinit var errorHandler: SdkContract.ErrorHandler
+    private lateinit var tags: HashMap<String, String>
+    private lateinit var encryptedTags: MutableList<String>
+    private val defaultAnnotation: MutableList<String> = mutableListOf()
+    private lateinit var encryptedAnnotations: MutableList<String>
+    // mark
+    private lateinit var encryptedRecord: EncryptedRecord
+
     @Before
     fun setUp() {
-        init()
+        apiService = mockk()
+        cryptoService = mockk()
+        fhirService = mockk()
+        tagEncryptionService = mockk()
+        taggingService = mockk()
+        attachmentService = mockk()
+        errorHandler = mockk()
+        tags = mockk()
+        encryptedTags = mockk()
+        encryptedAnnotations = mockk()
+        encryptedRecord = mockk(relaxed = true)
+
+        recordService = spyk(RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler
+        ))
     }
 
     @After
     fun tearDown() {
-        stop()
+        unmockkObject(RecordMapper)
     }
 
     @Test
@@ -58,18 +111,19 @@ class RecordServiceFetchRecordsTest : RecordServiceTestBase() {
             IOException::class,
             DataValidationException.ModelVersionNotSupported::class
     )
-    fun `Given, fetchRecord is called with a RecordId and UserId, it returns a Record`() {
+    fun `Given, fetchFhir3Record is called with a RecordId and UserId for an Fhir3Record, it returns a Record`() {
         // Given
-        Mockito.`when`(mockApiService.fetchRecord(ALIAS, USER_ID, RECORD_ID))
-                .thenReturn(Single.just(mockEncryptedRecord))
-        Mockito.doReturn(mockDecryptedFhir3Record)
-                .`when`(recordService)
-                .decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        @Suppress("UNCHECKED_CAST")
-        every { RecordMapper.getInstance(mockDecryptedFhir3Record) } returns mockRecord as BaseRecord<DomainResource>
+        val expected: Record<Fhir3CarePlan> = mockk()
+        val decrypted: DecryptedFhir3Record<Fhir3Resource> = mockk()
+        mockkObject(RecordMapper)
+
+        every { apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID) } returns Single.just(encryptedRecord)
+        every { recordService.decryptRecord<Fhir3Resource>(encryptedRecord, USER_ID) } returns decrypted
+        every { recordService.assignResourceId(decrypted) } returns decrypted
+        every { RecordMapper.getInstance(decrypted) } returns expected as BaseRecord<Fhir3Resource>
 
         // When
-        val observer = recordService.fetchFhir3Record<CarePlan>(USER_ID, RECORD_ID).test().await()
+        val observer = recordService.fetchFhir3Record<Fhir3CarePlan>(USER_ID, RECORD_ID).test().await()
 
         // Then
         val record = observer
@@ -78,25 +132,112 @@ class RecordServiceFetchRecordsTest : RecordServiceTestBase() {
                 .assertValueCount(1)
                 .values()[0]
 
-        Truth.assertThat(record).isSameInstanceAs(mockRecord)
+        assertSame<Record<Fhir3CarePlan>>(
+                expected = expected as Record<Fhir3CarePlan>,
+                actual = record
+        )
+        verify(exactly = 1) { apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord, USER_ID) }
+        verify(exactly = 1) { recordService.assignResourceId(decrypted) }
+        verify(exactly = 1) { RecordMapper.getInstance(decrypted) }
+    }
 
-        inOrder.verify(mockApiService).fetchRecord(ALIAS, USER_ID, RECORD_ID)
-        inOrder.verify(recordService).decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        inOrder.verify(recordService).assignResourceId(mockDecryptedFhir3Record)
-        inOrder.verifyNoMoreInteractions()
+    @Test
+    @Throws(
+            InterruptedException::class,
+            IOException::class,
+            DataValidationException.ModelVersionNotSupported::class
+    )
+    fun `Given, fetchFhir4Record is called with a RecordId and UserId for an Fhir4Record, it returns a Record`() {
+        // Given
+        val expected: Fhir4Record<Fhir4CarePlan> = mockk();
+        val decrypted: DecryptedFhir4Record<Fhir4Resource> = mockk()
+        mockkObject(RecordMapper)
+
+        every { apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID) } returns Single.just(encryptedRecord)
+        every { recordService.decryptRecord<Fhir4Resource>(encryptedRecord, USER_ID) } returns decrypted
+        every { recordService.assignResourceId(decrypted) } returns decrypted
+        every { RecordMapper.getInstance(decrypted) } returns expected as BaseRecord<Fhir4Resource>
+
+        // When
+        val observer = recordService.fetchFhir4Record<Fhir4CarePlan>(USER_ID, RECORD_ID).test().await()
+
+        // Then
+        val record = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertSame<Fhir4Record<Fhir4CarePlan>>(
+                expected = expected as Fhir4Record<Fhir4CarePlan>,
+                actual = record
+        )
+        verify(exactly = 1) { apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4Resource>(encryptedRecord, USER_ID) }
+        verify(exactly = 1) { recordService.assignResourceId(decrypted) }
+        verify(exactly = 1) { RecordMapper.getInstance(decrypted) }
+    }
+
+    @Test
+    @Throws(
+            InterruptedException::class,
+            IOException::class,
+            DataValidationException.ModelVersionNotSupported::class
+    )
+    fun `Given, fetchDataRecord is called with a RecordId and UserId for an DataRecord, it returns a Record`() {
+        // Given
+        val expected: DataRecord<DataResource> = mockk();
+        val decrypted: DecryptedDataRecord = mockk()
+        mockkObject(RecordMapper)
+
+        every { apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID) } returns Single.just(encryptedRecord)
+        every {
+            recordService.decryptRecord<DataResource>(encryptedRecord, USER_ID)
+        } returns decrypted as DecryptedBaseRecord<DataResource>
+        every { recordService.assignResourceId(decrypted) } returns decrypted
+        every { RecordMapper.getInstance(decrypted) } returns expected as BaseRecord<DataResource>
+
+        // When
+        val observer = recordService.fetchDataRecord(USER_ID, RECORD_ID).test().await()
+
+        // Then
+        val record = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertSame<DataRecord<DataResource>>(
+                expected = expected,
+                actual = record
+        )
+        verify(exactly = 1) { apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<DataResource>(encryptedRecord, USER_ID) }
+        verify(exactly = 1) { recordService.assignResourceId(decrypted) }
+        verify(exactly = 1) { RecordMapper.getInstance(decrypted) }
     }
 
     @Test
     @Throws(InterruptedException::class)
-    fun `Given, fetchRecords is called with multiple RecordIds and a UserId, it returns FetchedRecords`() {
-        // Given
-        Mockito.doReturn(Single.just(mockRecord))
-                .`when`(recordService)
-                .fetchFhir3Record<DomainResource>(RECORD_ID, USER_ID)
-        val ids = listOf(RECORD_ID, RECORD_ID)
-
+    fun `Given, fetchFhir3Records is called with multiple RecordIds and a UserId, it returns a List of Records`() {
+        //Given
+        val ids = listOf("1", "2", "3")
+        val record1: Record<Fhir3CarePlan> = mockk()
+        val record2: Record<Fhir3CarePlan> = mockk()
+        val record3: Record<Fhir3CarePlan> = mockk()
         // When
-        val observer = recordService.fetchFhir3Records<CarePlan>(ids, USER_ID).test().await()
+        every {
+            recordService.fetchFhir3Record<Fhir3CarePlan>(USER_ID, match { id -> ids[0] == id })
+        } returns Single.just(record1)
+        every {
+            recordService.fetchFhir3Record<Fhir3CarePlan>(USER_ID, match { id -> ids[1] == id })
+        } returns Single.just(record2)
+        every {
+            recordService.fetchFhir3Record<Fhir3CarePlan>(USER_ID, match { id -> ids[2] == id })
+        } returns Single.just(record3)
+
+        val observer = recordService.fetchFhir3Records<Fhir3CarePlan>(ids, USER_ID).test().await()
 
         // Then
         val result = observer
@@ -104,48 +245,115 @@ class RecordServiceFetchRecordsTest : RecordServiceTestBase() {
                 .assertComplete()
                 .assertValueCount(1)
                 .values()[0]
-        Truth.assertThat(result.successfulFetches).hasSize(2)
-        Truth.assertThat(result.failedFetches).hasSize(0)
-        inOrder.verify(recordService).fetchFhir3Records<DomainResource>(ids, USER_ID)
-        inOrder.verify(recordService, Mockito.times(2)).fetchFhir3Record<DomainResource>(RECORD_ID, USER_ID)
-        inOrder.verifyNoMoreInteractions()
+
+        assertEquals<List<Record<Fhir3CarePlan>>>(
+                expected = listOf(record1, record2, record3),
+                actual = result.successfulFetches
+        )
+    }
+
+    @Test
+    @Ignore(value="Timeout")
+    @Throws(InterruptedException::class)
+    fun `Given, fetchFhir3Records is called with multiple RecordIds and a UserId, it ignores errors`() {
+        //Given
+        val ids = listOf("1", "2", "3")
+        val record1: Record<Fhir3CarePlan> = mockk()
+        val record3: Record<Fhir3CarePlan> = mockk()
+        val decrypted: DecryptedFhir3Record<Fhir3CarePlan> = mockk()
+        val thrownError = RuntimeException("error")
+        val expectedError: D4LException = mockk()
+
+        mockkObject(RecordMapper)
+
+        // When
+        every {
+            recordService.fetchFhir3Record<Fhir3CarePlan>(USER_ID, match { id -> ids[0] == id })
+        } returns Single.just(record1)
+
+        every { apiService.fetchRecord(ALIAS, USER_ID, ids[1]) } returns Single.just(encryptedRecord)
+        every {
+            recordService.decryptRecord<Fhir3Resource>(encryptedRecord, USER_ID)
+        } returns decrypted as DecryptedBaseRecord<Fhir3Resource>
+        every { recordService.assignResourceId(decrypted) } returns decrypted
+        every { RecordMapper.getInstance(decrypted) } throws thrownError
+        every { errorHandler.handleError(thrownError) } returns expectedError
+
+        every {
+            recordService.fetchFhir3Record<Fhir3CarePlan>(USER_ID, match { id -> ids[2] == id })
+        } returns Single.just(record3)
+
+        val observer = recordService.fetchFhir3Records<Fhir3CarePlan>(ids, USER_ID).test().await()
+
+        // Then
+        val result = observer
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals<List<Record<Fhir3CarePlan>>>(
+                expected = listOf(record1, record3),
+                actual = result.successfulFetches
+        )
     }
 
     @Test
     @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
-    fun `Given, fetchRecords called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize and Offset, it returns FetchedRecords`() {
+    fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it returns List of Records`() {
         // Given
-        val encryptedRecords = listOf(mockEncryptedRecord, mockEncryptedRecord)
-        Mockito.`when`(mockTaggingService.getTagFromType(CarePlan::class.java as Class<Any>)).thenReturn(mockTags)
-        Mockito.`when`(mockTagEncryptionService.encryptTags(mockTags)).thenReturn(mockEncryptedTags)
-        Mockito.`when`(
-                mockTagEncryptionService.encryptAnnotations(listOf())
-        ).thenReturn(mockEncryptedAnnotations)
-        Mockito.`when`(
-                mockApiService.fetchRecords(
-                        ArgumentMatchers.eq(ALIAS),
-                        ArgumentMatchers.eq(USER_ID),
-                        ArgumentMatchers.isNull(),
-                        ArgumentMatchers.isNull(),
-                        ArgumentMatchers.eq(10),
-                        ArgumentMatchers.eq(0),
-                        ArgumentMatchers.eq(mockEncryptedTags)
-                )
-        ).thenReturn(Observable.just(encryptedRecords))
-        Mockito.doReturn(mockDecryptedFhir3Record)
-                .`when`(recordService)
-                .decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        @Suppress("UNCHECKED_CAST")
-        every { RecordMapper.getInstance(mockDecryptedFhir3Record) } returns mockRecord as BaseRecord<DomainResource>
+        val resource1: Fhir3CarePlan = mockk()
+        val resource2: Fhir3CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir3Record<Fhir3CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir3Record<Fhir3CarePlan>  = mockk(relaxed = true)
+        val record1: Record<Fhir3CarePlan> = mockk()
+        val record2: Record<Fhir3CarePlan> = mockk()
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        mockkObject(RecordMapper)
+
+        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
+        every {
+            hint(Fhir3CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns defaultAnnotation
+        every {
+            hint(Fhir3CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
+        every { RecordMapper.getInstance(decryptedRecord2) } returns record2
 
         // When
         val observer = recordService.fetchFhir3Records(
                 USER_ID,
-                CarePlan::class.java,
+                Fhir3CarePlan::class.java,
                 null,
                 null,
-                10,
-                0
+                pageSize,
+                offset
         ).test().await()
 
         // Then
@@ -154,66 +362,103 @@ class RecordServiceFetchRecordsTest : RecordServiceTestBase() {
                 .assertComplete()
                 .assertValueCount(1)
                 .values()[0]
-        Truth.assertThat(fetched).hasSize(2)
-        Truth.assertThat(fetched[0].meta).isEqualTo(mockMeta)
-        Truth.assertThat(fetched[0].fhirResource).isEqualTo(mockCarePlan)
-        Truth.assertThat(fetched[1].meta).isEqualTo(mockMeta)
-        Truth.assertThat(fetched[1].fhirResource).isEqualTo(mockCarePlan)
-        inOrder.verify(mockTaggingService).getTagFromType(CarePlan::class.java as Class<Any>)
-        inOrder.verify(mockTagEncryptionService).encryptTags(mockTags)
-        inOrder.verify(mockTagEncryptionService).encryptAnnotations(listOf())
-        inOrder.verify(mockApiService).fetchRecords(
-                ArgumentMatchers.eq(ALIAS),
-                ArgumentMatchers.eq(USER_ID),
-                ArgumentMatchers.isNull(),
-                ArgumentMatchers.isNull(),
-                ArgumentMatchers.eq(10),
-                ArgumentMatchers.eq(0),
-                ArgumentMatchers.eq(mockEncryptedTags)
+
+        assertEquals(
+                expected = 2,
+                actual = fetched.size
         )
-        inOrder.verify(recordService).decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        inOrder.verify(recordService).assignResourceId(mockDecryptedFhir3Record)
-        inOrder.verify(recordService).decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        inOrder.verify(recordService).assignResourceId(mockDecryptedFhir3Record)
-        inOrder.verifyNoMoreInteractions()
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        assertSame(
+                expected = record2,
+                actual = fetched[1]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
+        verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord2) }
     }
 
     @Test
     @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
-    fun `Given, fetchRecords called with a UserId, a ResourceType, Annotations, a StartDate, a EndDate, the PageSize and Offset, it returns FetchedRecords`() {
+    fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize and Offset, it returns List of Records`() {
         // Given
-        val encryptedRecords = listOf(mockEncryptedRecord, mockEncryptedRecord)
-        Mockito.`when`(mockTaggingService.getTagFromType(CarePlan::class.java as Class<Any>)).thenReturn(mockTags)
-        Mockito.`when`(mockTagEncryptionService.encryptTags(mockTags)).thenReturn(mockEncryptedTags)
-        Mockito.`when`(
-                mockTagEncryptionService.encryptAnnotations(ANNOTATIONS)
-        ).thenReturn(mockEncryptedAnnotations)
-        Mockito.`when`(
-                mockApiService.fetchRecords(
-                        ArgumentMatchers.eq(ALIAS),
-                        ArgumentMatchers.eq(USER_ID),
-                        ArgumentMatchers.isNull(),
-                        ArgumentMatchers.isNull(),
-                        ArgumentMatchers.eq(10),
-                        ArgumentMatchers.eq(0),
-                        ArgumentMatchers.eq(mockEncryptedTags)
-                )
-        ).thenReturn(Observable.just(encryptedRecords))
-        Mockito.doReturn(mockAnnotatedDecryptedFhirRecord)
-                .`when`(recordService)
-                .decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        @Suppress("UNCHECKED_CAST")
-        every { RecordMapper.getInstance(mockAnnotatedDecryptedFhirRecord) } returns mockRecord as BaseRecord<DomainResource>
+        val resource1: Fhir3CarePlan = mockk()
+        val resource2: Fhir3CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir3Record<Fhir3CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir3Record<Fhir3CarePlan>  = mockk(relaxed = true)
+        val record1: Record<Fhir3CarePlan> = mockk()
+        val record2: Record<Fhir3CarePlan> = mockk()
+        val startDate: LocalDate = mockk()
+        val start = "start"
+        val endDate: LocalDate = mockk()
+        val end = "end"
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        mockkObject(RecordMapper)
+        mockkObject(RecordService)
+
+        every { RecordService.formatDate(startDate) } returns start
+        every { RecordService.formatDate(endDate) } returns end
+        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                start,
+                end,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
+
+        every {
+            hint(Fhir3CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns defaultAnnotation
+        every {
+            hint(Fhir3CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
+        every { RecordMapper.getInstance(decryptedRecord2) } returns record2
 
         // When
         val observer = recordService.fetchFhir3Records(
                 USER_ID,
-                CarePlan::class.java,
-                ANNOTATIONS,
-                null,
-                null,
-                10,
-                0
+                Fhir3CarePlan::class.java,
+                startDate,
+                endDate,
+                pageSize,
+                offset
         ).test().await()
 
         // Then
@@ -222,271 +467,788 @@ class RecordServiceFetchRecordsTest : RecordServiceTestBase() {
                 .assertComplete()
                 .assertValueCount(1)
                 .values()[0]
-        Truth.assertThat(fetched).hasSize(2)
-        Truth.assertThat(fetched[0].meta).isEqualTo(mockMeta)
-        Truth.assertThat(fetched[0].fhirResource).isEqualTo(mockCarePlan)
-        Truth.assertThat(fetched[1].meta).isEqualTo(mockMeta)
-        Truth.assertThat(fetched[1].fhirResource).isEqualTo(mockCarePlan)
-        inOrder.verify(mockTaggingService).getTagFromType(CarePlan::class.java as Class<Any>)
-        inOrder.verify(mockTagEncryptionService).encryptTags(mockTags)
-        inOrder.verify(mockTagEncryptionService).encryptAnnotations(ANNOTATIONS)
-        inOrder.verify(mockApiService).fetchRecords(
-                ArgumentMatchers.eq(ALIAS),
-                ArgumentMatchers.eq(USER_ID),
-                ArgumentMatchers.isNull(),
-                ArgumentMatchers.isNull(),
-                ArgumentMatchers.eq(10),
-                ArgumentMatchers.eq(0),
-                ArgumentMatchers.eq(mockEncryptedTags)
+
+        assertEquals(
+                expected = 2,
+                actual = fetched.size
         )
-        inOrder.verify(recordService).decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        inOrder.verify(recordService).assignResourceId(mockAnnotatedDecryptedFhirRecord)
-        inOrder.verify(recordService).decryptRecord<DomainResource>(mockEncryptedRecord, USER_ID)
-        inOrder.verify(recordService).assignResourceId(mockAnnotatedDecryptedFhirRecord)
-        inOrder.verifyNoMoreInteractions()
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        assertSame(
+                expected = record2,
+                actual = fetched[1]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
+        verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
+        verify(exactly = 1) { RecordService.formatDate(startDate) }
+        verify(exactly = 1) { RecordService.formatDate(endDate) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                start,
+                end,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord2) }
+
+        unmockkObject(RecordService)
     }
 
     @Test
-    fun `Given, fetchDataRecord is called with UserId and a RecordId for a DataRecord, it to the generic fetchRecord and returns its Result`() {
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it filters by the ResourceType`() {
         // Given
-        val userId = "id"
-        val recordId = "123"
+        val resource1: Fhir3CarePlan = mockk()
+        val resource2: Fhir3Resource = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir3Record<Fhir3CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir3Record<Fhir3Resource>  = mockk(relaxed = true)
+        val record1: Record<Fhir3CarePlan> = mockk()
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        mockkObject(RecordMapper)
 
-        val createdRecord = mockk<DataRecord<DataResource>>()
-
-        @Suppress("UNCHECKED_CAST")
+        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
         every {
-            recordServiceK._fetchRecord<Any>(recordId, userId)
-        } returns Single.just(createdRecord as BaseRecord<Any>)
+            hint(Fhir3CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns defaultAnnotation
+        every {
+            hint(Fhir3Resource::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir3Resource>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
 
         // When
-        val subscriber = recordServiceK.fetchDataRecord(
-                userId,
-                recordId
+        val observer = recordService.fetchFhir3Records(
+                USER_ID,
+                Fhir3CarePlan::class.java,
+                null,
+                null,
+                pageSize,
+                offset
         ).test().await()
 
-        val record = subscriber
+        // Then
+        val fetched = observer
                 .assertNoErrors()
                 .assertComplete()
                 .assertValueCount(1)
                 .values()[0]
 
-        // Then
-        assertSame(
-                record,
-                createdRecord
+        assertEquals(
+                expected = 1,
+                actual = fetched.size
         )
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
+        verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3Resource>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
     }
 
     @Test
-    fun `Given, fetchFhir3Record is called with UserId and a RecordId for a Fhir3Resources, it to the generic fetchRecord and return its Result`() {
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it filters by the given Annotations`() {
         // Given
-        val userId = "id"
-        val recordId = "123"
+        val resource1: Fhir3CarePlan = mockk()
+        val resource2: Fhir3CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir3Record<Fhir3CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir3Record<Fhir3CarePlan>  = mockk(relaxed = true)
+        val record1: Record<Fhir3CarePlan> = mockk()
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val annotations = listOf("potato", "soup")
 
-        val createdRecord = mockk<Record<Fhir3Resource>>()
+        mockkObject(RecordMapper)
 
-        @Suppress("UNCHECKED_CAST")
+        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { encryptedTags.addAll(annotations) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
         every {
-            recordServiceK._fetchRecord<Any>(recordId, userId)
-        } returns Single.just(createdRecord as BaseRecord<Any>)
+            hint(Fhir3CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns annotations
+        every {
+            hint(Fhir3CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
 
         // When
-        val subscriber = recordServiceK.fetchFhir3Record<Fhir3Resource>(
-                userId,
-                recordId
-        ).test().await()
-
-        val record = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
-
-        // Then
-        assertSame(
-                record,
-                createdRecord
-        )
-    }
-
-    @Test
-    fun `Given, fetchFhir4Record is called with UserId and a RecordId, it to the generic fetchRecord and return its Result`() {
-        // Given
-        val userId = "id"
-        val recordId = "123"
-
-        val createdRecord = mockk<Fhir4Record<Fhir4Resource>>()
-
-        @Suppress("UNCHECKED_CAST")
-        every {
-            recordServiceK._fetchRecord<Any>(recordId, userId)
-        } returns Single.just(createdRecord as BaseRecord<Any>)
-
-        // When
-        val subscriber = recordServiceK.fetchFhir4Record<Fhir4Resource>(
-                userId,
-                recordId
-        ).test().await()
-
-        val record = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
-
-        // Then
-        assertSame(
-                record,
-                createdRecord
-        )
-    }
-
-    @Test
-    fun `Given, fetchDataRecords is called with a UserId, Annotations, a StartDate, a EndDate, the PageSize and Offset, it delegates to the generic fetchRecord and returns its Result`() {
-        // Given
-        val userId = "abc"
-        val annotations = mockk<List<String>>()
-        val startDate = mockk<LocalDate>()
-        val endDate = mockk<LocalDate>()
-        val pageSize = 123
-        val offset = 2
-
-        val fetchedRecords = listOf(mockk<DataRecord<DataResource>>())
-
-        @Suppress("UNCHECKED_CAST")
-        every {
-            recordServiceK._fetchRecords<Any>(
-                    userId,
-                    null,
-                    annotations,
-                    startDate,
-                    endDate,
-                    pageSize,
-                    offset
-            )
-        } returns Single.just(fetchedRecords as List<BaseRecord<Any>>)
-
-        // When
-        val observer = recordServiceK.fetchDataRecords(
-                userId,
+        val observer = recordService.fetchFhir3Records(
+                USER_ID,
+                Fhir3CarePlan::class.java,
                 annotations,
+                null,
+                null,
+                pageSize,
+                offset
+        ).test().await()
+
+        // Then
+        val fetched = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = 1,
+                actual = fetched.size
+        )
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it filters by the given Annotations and ResourceType`() {
+        // Given
+        val resource1: Fhir3Resource = mockk()
+        val resource2: Fhir3CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir3Record<Fhir3Resource> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir3Record<Fhir3CarePlan>  = mockk(relaxed = true)
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val annotations = listOf("potato", "soup")
+
+        mockkObject(RecordMapper)
+
+        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { encryptedTags.addAll(annotations) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
+        every {
+            hint(Fhir3Resource::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns annotations
+        every {
+            hint(Fhir3CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir3Resource>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+
+        // When
+        val observer = recordService.fetchFhir3Records(
+                USER_ID,
+                Fhir3CarePlan::class.java,
+                annotations,
+                null,
+                null,
+                pageSize,
+                offset
+        ).test().await()
+
+        // Then
+        val fetched = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = 0,
+                actual = fetched.size
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3Resource>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir3CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 0) { RecordMapper.getInstance(any<DecryptedFhir3Record<Fhir3Resource>>()) }
+    }
+    // mark
+    @Test
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it returns List of Fhir4Records`() {
+        // Given
+        val resource1: Fhir4CarePlan = mockk()
+        val resource2: Fhir4CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir4Record<Fhir4CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir4Record<Fhir4CarePlan>  = mockk(relaxed = true)
+        val record1: Fhir4Record<Fhir4CarePlan> = mockk()
+        val record2: Fhir4Record<Fhir4CarePlan> = mockk()
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        mockkObject(RecordMapper)
+
+        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
+        every {
+            hint(Fhir4CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns defaultAnnotation
+        every {
+            hint(Fhir4CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
+        every { RecordMapper.getInstance(decryptedRecord2) } returns record2
+
+        // When
+        val observer = recordService.fetchFhir4Records(
+                USER_ID,
+                Fhir4CarePlan::class.java,
+                listOf(),
+                null,
+                null,
+                pageSize,
+                offset
+        ).test().await()
+
+        // Then
+        val fetched = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = 2,
+                actual = fetched.size
+        )
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        assertSame(
+                expected = record2,
+                actual = fetched[1]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
+        verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord2) }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize and Offset, it returns List of Fhir4Records`() {
+        // Given
+        val resource1: Fhir4CarePlan = mockk()
+        val resource2: Fhir4CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir4Record<Fhir4CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir4Record<Fhir4CarePlan>  = mockk(relaxed = true)
+        val record1: Fhir4Record<Fhir4CarePlan> = mockk()
+        val record2: Fhir4Record<Fhir4CarePlan> = mockk()
+        val startDate: LocalDate = mockk()
+        val start = "start"
+        val endDate: LocalDate = mockk()
+        val end = "end"
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        mockkObject(RecordMapper)
+        mockkObject(RecordService)
+
+        every { RecordService.formatDate(startDate) } returns start
+        every { RecordService.formatDate(endDate) } returns end
+        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                start,
+                end,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
+
+        every {
+            hint(Fhir4CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns defaultAnnotation
+        every {
+            hint(Fhir4CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
+        every { RecordMapper.getInstance(decryptedRecord2) } returns record2
+
+        // When
+        val observer = recordService.fetchFhir4Records(
+                USER_ID,
+                Fhir4CarePlan::class.java,
+                listOf(),
                 startDate,
                 endDate,
                 pageSize,
                 offset
         ).test().await()
 
-        val record = observer
+        // Then
+        val fetched = observer
                 .assertNoErrors()
                 .assertComplete()
                 .assertValueCount(1)
                 .values()[0]
 
-        // Then
-        assertSame(
-                record,
-                fetchedRecords
+        assertEquals(
+                expected = 2,
+                actual = fetched.size
         )
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        assertSame(
+                expected = record2,
+                actual = fetched[1]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
+        verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
+        verify(exactly = 1) { RecordService.formatDate(startDate) }
+        verify(exactly = 1) { RecordService.formatDate(endDate) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                start,
+                end,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord2) }
+
+        unmockkObject(RecordService)
     }
 
     @Test
-    fun `Given, fetchFhir3Records is called with a UserId, a ResourceType, Annotations, a StartDate, a EndDate, the PageSize and Offset, it to the generic fetchRecord and returns its Result`() {
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it filters by the ResourceType`() {
         // Given
-        val userId = "abc"
-        val klass = Fhir3Resource::class.java
-        val annotations = mockk<List<String>>()
-        val startDate = mockk<LocalDate>(relaxed = true)
-        val endDate = mockk<LocalDate>(relaxed = true)
-        val pageSize = 123
-        val offset = 2
+        val resource1: Fhir4CarePlan = mockk()
+        val resource2: Fhir4Resource = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir4Record<Fhir4CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir4Record<Fhir4Resource>  = mockk(relaxed = true)
+        val record1: Fhir4Record<Fhir4CarePlan> = mockk()
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        mockkObject(RecordMapper)
 
-        val fetchedRecords = listOf(mockk<Record<Fhir3Resource>>())
-
-        @Suppress("UNCHECKED_CAST")
+        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
         every {
-            recordServiceK._fetchRecords(
-                    userId,
-                    klass,
-                    annotations,
-                    startDate,
-                    endDate,
-                    pageSize,
-                    offset
-            )
-        } returns Single.just(fetchedRecords)
+            hint(Fhir4CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns defaultAnnotation
+        every {
+            hint(Fhir4Resource::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir4Resource>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
 
         // When
-        val observer = recordServiceK.fetchFhir3Records(
-                userId,
-                klass,
-                annotations,
-                startDate,
-                endDate,
+        val observer = recordService.fetchFhir4Records(
+                USER_ID,
+                Fhir4CarePlan::class.java,
+                listOf(),
+                null,
+                null,
                 pageSize,
                 offset
         ).test().await()
 
-        val record = observer
+        // Then
+        val fetched = observer
                 .assertNoErrors()
                 .assertComplete()
                 .assertValueCount(1)
                 .values()[0]
 
-        // Then
-        assertSame(
-                record,
-                fetchedRecords
+        assertEquals(
+                expected = 1,
+                actual = fetched.size
         )
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
+        verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4Resource>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
     }
 
     @Test
-    fun `Given, fetchFhir4Records is called with a UserId, a ResourceType, Annotations, a StartDate, a EndDate, the PageSize and Offset, it to the generic fetchRecord and returns its Result`() {
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it filters by the given Annotations`() {
         // Given
-        val userId = "abc"
-        val klass = Fhir4Resource::class.java
-        val annotations = mockk<List<String>>()
-        val startDate = mockk<LocalDate>(relaxed = true)
-        val endDate = mockk<LocalDate>(relaxed = true)
-        val pageSize = 123
-        val offset = 2
+        val resource1: Fhir4CarePlan = mockk()
+        val resource2: Fhir4CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir4Record<Fhir4CarePlan> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir4Record<Fhir4CarePlan>  = mockk(relaxed = true)
+        val record1: Fhir4Record<Fhir4CarePlan> = mockk()
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val annotations = listOf("potato", "soup")
 
-        val fetchedRecords = listOf(mockk<Fhir4Record<Fhir4Resource>>())
+        mockkObject(RecordMapper)
 
-        @Suppress("UNCHECKED_CAST")
+        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { encryptedTags.addAll(annotations) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
         every {
-            recordServiceK._fetchRecords(
-                    userId,
-                    klass as Class<Any>,
-                    annotations,
-                    startDate,
-                    endDate,
-                    pageSize,
-                    offset
-            )
-        } returns Single.just(fetchedRecords as List<BaseRecord<Any>>)
+            hint(Fhir4CarePlan::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns annotations
+        every {
+            hint(Fhir4CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+        every { RecordMapper.getInstance(decryptedRecord1) } returns record1
 
         // When
-        val observer = recordServiceK.fetchFhir4Records(
-                userId,
-                klass,
+        val observer = recordService.fetchFhir4Records(
+                USER_ID,
+                Fhir4CarePlan::class.java,
                 annotations,
-                startDate,
-                endDate,
+                null,
+                null,
                 pageSize,
                 offset
         ).test().await()
 
-        val record = observer
+        // Then
+        val fetched = observer
                 .assertNoErrors()
                 .assertComplete()
                 .assertValueCount(1)
                 .values()[0]
 
-        // Then
-        assertSame(
-                record,
-                fetchedRecords
+        assertEquals(
+                expected = 1,
+                actual = fetched.size
         )
+        assertSame(
+                expected = record1,
+                actual = fetched[0]
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 1) { RecordMapper.getInstance(decryptedRecord1) }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class, DataValidationException.ModelVersionNotSupported::class)
+    fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it filters by the given Annotations and ResourceType`() {
+        // Given
+        val resource1: Fhir4Resource = mockk()
+        val resource2: Fhir4CarePlan = mockk()
+        val encryptedRecord1: EncryptedRecord = mockk()
+        val encryptedRecord2: EncryptedRecord = mockk()
+        val decryptedRecord1: DecryptedFhir4Record<Fhir4Resource> = mockk(relaxed = true)
+        val decryptedRecord2: DecryptedFhir4Record<Fhir4CarePlan>  = mockk(relaxed = true)
+        val offset = 42
+        val pageSize = 23
+        val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val annotations = listOf("potato", "soup")
+
+        mockkObject(RecordMapper)
+
+        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
+        every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
+        every { encryptedTags.addAll(defaultAnnotation) } returns true
+        every { encryptedTags.addAll(annotations) } returns true
+        every { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) } returns Observable.fromArray(encryptedRecords)
+        every {
+            hint(Fhir4Resource::class)
+            decryptedRecord1.resource
+        } returns resource1
+        every { decryptedRecord1.annotations } returns annotations
+        every {
+            hint(Fhir4CarePlan::class)
+            decryptedRecord2.resource
+        } returns resource2
+        every { decryptedRecord2.annotations } returns defaultAnnotation
+        every {
+            recordService.decryptRecord<Fhir4Resource>(encryptedRecord1, USER_ID)
+        } returns decryptedRecord1
+        every {
+            recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID)
+        } returns decryptedRecord2
+
+        // When
+        val observer = recordService.fetchFhir4Records(
+                USER_ID,
+                Fhir4CarePlan::class.java,
+                annotations,
+                null,
+                null,
+                pageSize,
+                offset
+        ).test().await()
+
+        // Then
+        val fetched = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = 0,
+                actual = fetched.size
+        )
+        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
+        verify(exactly = 1) { apiService.fetchRecords(
+                ALIAS,
+                USER_ID,
+                null,
+                null,
+                pageSize,
+                offset,
+                encryptedTags
+        ) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4Resource>(encryptedRecord1, USER_ID) }
+        verify(exactly = 1) { recordService.decryptRecord<Fhir4CarePlan>(encryptedRecord2, USER_ID) }
+        verify(exactly = 0) { RecordMapper.getInstance(any<DecryptedFhir4Record<Fhir4Resource>>()) }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the legacy batch methods deleteRecords and fetchRecords delegate their parameters in the wrong order to the underlying calls.

## Motivation and Context
This fixes only `fetchRecords`. See #53 for `deleteRecords`.
During the refactoring of the `RecordServiceFetchRecordsTest` the bug was spotted.

## How is it being implemented?
The `LegacyClient` and `RecordService` methods had been fixed.

## How Has This Been Tested?
`RecordServiceFetchRecordsTest` had been refactored with the appropriate changes. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
