### PR TITLE
[SDK-523] Add countRecords support for Fhir4

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,8 @@ toc::[]
 === Added
 
 * Add information how to use matching fallbacks for Android to README
+* `count` to Fhir4Client
+* `countFhir3Records`, `countFhir4Records` and `countAllFhir3Records` to RecordService
 
 === Changed
 
@@ -37,13 +39,14 @@ toc::[]
 * RecordService#deleteRecord invocation had mixed user and resource id.
 * RecordService#fetchRecords invocation had mixed user and resource id.
 * NullPointerException when using DomainResource as resourceType for fetch/search.
+* RecordService#countRecords filters now with Annotation when counting all Fhir3Records.
 
 === Bumped
 
 === Migration
 
 * TODO: search strategy (fetchRecords) for the encoded tags (especially in regards to the Fhir version)
-
+* RecordService#countRecords is now deprecated
 
 == https://github.com/d4l-data4life/hc-sdk-kmp/compare/v1.9.0...v1.9.1[1.9.1]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,7 +46,6 @@ toc::[]
 === Migration
 
 * TODO: search strategy (fetchRecords) for the encoded tags (especially in regards to the Fhir version)
-* RecordService#countRecords is now deprecated
 
 == https://github.com/d4l-data4life/hc-sdk-kmp/compare/v1.9.0...v1.9.1[1.9.1]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -47,6 +47,7 @@ toc::[]
 
 * TODO: search strategy (fetchRecords) for the encoded tags (especially in regards to the Fhir version)
 
+
 == https://github.com/d4l-data4life/hc-sdk-kmp/compare/v1.9.0...v1.9.1[1.9.1]
 
 === Fixed

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -286,7 +286,7 @@ class RecordService(
         val endTime = if (endDate != null) formatDate(endDate) else null
 
         return Observable
-                .fromCallable { taggingService.getTagFromType(resourceType as Class<Any>?) }
+                .fromCallable { taggingService.getTagsFromType(resourceType as Class<Any>?) }
                 .map { plainTags -> encryptTagsAndAnnotations(plainTags, annotations) }
                 .flatMap {
                     encryptedTags -> apiService.fetchRecords(
@@ -524,7 +524,7 @@ class RecordService(
         apiService.getCount(alias, userId, null)
     } else {
         Single
-                .fromCallable { taggingService.getTagFromType(type as Class<Any>?) }
+                .fromCallable { taggingService.getTagsFromType(type as Class<Any>?) }
                 .map { plainTags -> encryptTagsAndAnnotations(plainTags, annotations) }
                 .flatMap { apiService.getCount(alias, userId, it) }
     }

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -54,7 +54,6 @@ import care.data4life.sdk.network.model.definitions.DecryptedFhir3Record
 import care.data4life.sdk.network.model.definitions.DecryptedFhir4Record
 import care.data4life.sdk.record.RecordContract
 import care.data4life.sdk.tag.TaggingContract
-import care.data4life.sdk.tag.Tags
 import care.data4life.sdk.util.Base64.decode
 import care.data4life.sdk.util.Base64.encodeToString
 import care.data4life.sdk.util.HashUtil.sha1
@@ -516,7 +515,7 @@ class RecordService(
                 .map { UpdateResult(it, failedUpdates) }
     }
 
-    private fun countTypedRecords(
+    private fun _countRecords(
             type: Class<out Any>,
             userId: String,
             annotations: List<String> = listOf()
@@ -543,13 +542,13 @@ class RecordService(
             type: Class<out Fhir3Resource>,
             userId: String,
             annotations: List<String>
-    ): Single<Int> = countTypedRecords(type, userId, annotations)
+    ): Single<Int> = _countRecords(type, userId, annotations)
 
     override fun countFhir4Records(
             type: Class<out Fhir4Resource>,
             userId: String,
             annotations: List<String>
-    ): Single<Int> = countTypedRecords(type, userId, annotations)
+    ): Single<Int> = _countRecords(type, userId, annotations)
 
     override fun countAllFhir3Records(
             userId: String,

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -91,12 +91,12 @@ class RecordService(
         private val cryptoService: CryptoService,
         private val errorHandler: SdkContract.ErrorHandler
 ) : RecordContract.Service {
-    @Deprecated("This method will be removed in the next major release.")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     internal enum class UploadDownloadOperation {
         UPLOAD, DOWNLOAD, UPDATE
     }
 
-    @Deprecated("This method will be removed in the next major release.")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     internal enum class RemoveRestoreOperation {
         REMOVE, RESTORE
     }
@@ -546,7 +546,7 @@ class RecordService(
     )
 
     @JvmOverloads
-    @Deprecated("This method will be removed in the next major release.")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     fun countRecords(
             type: Class<out Fhir3Resource>?,
             userId: String,
@@ -832,7 +832,7 @@ class RecordService(
         }
     }
 
-    @Deprecated("This method will be removed in the next major release.")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     internal fun <T : Fhir3Resource> removeOrRestoreUploadData(
             operation: RemoveRestoreOperation,
             record: DecryptedFhir3Record<T>,
@@ -1022,7 +1022,7 @@ class RecordService(
     // This method should not allowed to exist any longer in this shape. _uploadData should take over
     // as soon as possible so we can get rid of uploadOrDownloadData. This also means uploadData should
     // not be responsible for the actual upload and a update.
-    @Deprecated("This method will be removed in the next major release.")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     @Throws(DataValidationException.IdUsageViolation::class,
             DataValidationException.ExpectedFieldViolation::class,
             DataValidationException.InvalidAttachmentPayloadHash::class)
@@ -1038,7 +1038,7 @@ class RecordService(
         }
     }
 
-    @Deprecated("This method will be removed in the next major release.")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     @Throws(DataValidationException.IdUsageViolation::class,
             DataValidationException.ExpectedFieldViolation::class,
             DataValidationException.InvalidAttachmentPayloadHash::class,
@@ -1210,7 +1210,7 @@ class RecordService(
         }
     }
 
-    @Deprecated("This method will be removed in the next major release.")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     internal fun buildMeta(
             record: DecryptedBaseRecord<*>
     ): Meta = Meta(

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -536,12 +536,12 @@ class RecordService(
     )
 
     private fun countTypedRecords(
-            type: Class<out Fhir3Resource>,
+            type: Class<Any>,
             userId: String,
             annotations: List<String> = listOf()
     ): Single<Int> = _countRecords(
             userId,
-            { taggingService.getTagsFromType(type as Class<Any>) },
+            { taggingService.getTagsFromType(type) },
             annotations
     )
 
@@ -559,16 +559,22 @@ class RecordService(
         }
     }
 
-    override fun countAllFhir3Records(
-            userId: String,
-            annotations: List<String>
-    ): Single<Int> = countAllRecords(userId, FhirContract.FhirVersion.FHIR_3, annotations)
-
     override fun countFhir3Records(
             type: Class<out Fhir3Resource>,
             userId: String,
             annotations: List<String>
-    ): Single<Int> = countTypedRecords(type, userId, annotations)
+    ): Single<Int> = countTypedRecords(type as Class<Any>, userId, annotations)
+
+    override fun countFhir4Records(
+            type: Class<out Fhir4Resource>,
+            userId: String,
+            annotations: List<String>
+    ): Single<Int> = countTypedRecords(type as Class<Any>, userId, annotations)
+
+    override fun countAllFhir3Records(
+            userId: String,
+            annotations: List<String>
+    ): Single<Int> = countAllRecords(userId, FhirContract.FhirVersion.FHIR_3, annotations)
 
     //region utility methods
     @Throws(IOException::class)

--- a/sdk-core/src/main/java/care/data4life/sdk/SdkContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/SdkContract.kt
@@ -123,6 +123,16 @@ interface SdkContract {
                 offset: Int,
                 callback: Callback<List<Fhir4Record<T>>>
         ): Task
+
+        /**
+         * Count {@link Fhir4Record}s
+         *
+         * @param resourceType class type of the searched resource
+         * @param annotations custom annotations added as tags to the record
+         * @param callback    either {@link Callback#onSuccess(Object)} or {@link Callback#onError(D4LException)} will be called
+         * @return            {@link Task} which can be used to cancel ongoing operation or to query operation status
+         */
+        fun <T : Fhir4Resource> count(resourceType: Class<T>, annotations: List<String>, callback: Callback<Int>): Task
     }
 
     interface DataRecordClient {

--- a/sdk-core/src/main/java/care/data4life/sdk/fhir/Fhir4RecordClient.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/fhir/Fhir4RecordClient.kt
@@ -38,7 +38,12 @@ internal class Fhir4RecordClient(
         return handler.executeSingle(operation, callback)
     }
 
-    override fun <T : Fhir4Resource> update(recordId: String, resource: T, annotations: List<String>, callback: Callback<Fhir4Record<T>>): Task {
+    override fun <T : Fhir4Resource> update(
+            recordId: String,
+            resource: T,
+            annotations: List<String>,
+            callback: Callback<Fhir4Record<T>>
+    ): Task {
         val operation = userService.finishLogin(true)
                 .flatMap { userService.uID }
                 .flatMap { uid -> recordService.updateRecord(uid, recordId, resource, annotations) }
@@ -59,7 +64,14 @@ internal class Fhir4RecordClient(
         return handler.executeSingle(operation, callback)
     }
 
-    override fun <T : Fhir4Resource> search(resourceType: Class<T>, annotations: List<String>, startDate: LocalDate?, endDate: LocalDate?, pageSize: Int, offset: Int, callback: Callback<List<Fhir4Record<T>>>): Task {
+    override fun <T : Fhir4Resource> search(
+            resourceType: Class<T>,
+            annotations: List<String>,
+            startDate: LocalDate?, endDate: LocalDate?,
+            pageSize: Int,
+            offset: Int,
+            callback: Callback<List<Fhir4Record<T>>>
+    ): Task {
         val operation = userService.finishLogin(true)
                 .flatMap { userService.uID }
                 .flatMap { uid ->
@@ -71,6 +83,23 @@ internal class Fhir4RecordClient(
                             endDate,
                             pageSize,
                             offset
+                    )
+                }
+        return handler.executeSingle(operation, callback)
+    }
+
+    override fun <T : Fhir4Resource> count(
+            resourceType: Class<T>,
+            annotations: List<String>,
+            callback: Callback<Int>
+    ): Task {
+        val operation = userService.finishLogin(true)
+                .flatMap { userService.uID }
+                .flatMap { uid ->
+                    recordService.countFhir4Records(
+                            resourceType,
+                            uid,
+                            annotations
                     )
                 }
         return handler.executeSingle(operation, callback)

--- a/sdk-core/src/main/java/care/data4life/sdk/fhir/FhirService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/fhir/FhirService.kt
@@ -42,7 +42,7 @@ class FhirService @JvmOverloads constructor(
 ) : FhirContract.Service {
     private val parser: WrapperContract.FhirParser = SdkFhirParser
 
-    @Deprecated("Use the new Api")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     @Suppress("UNCHECKED_CAST")
     fun <T : Fhir3Resource> decryptResource(dataKey: GCKey, resourceType: String, encryptedResource: String): T {
         return Single
@@ -60,7 +60,7 @@ class FhirService @JvmOverloads constructor(
                 .blockingGet() as T
     }
 
-    @Deprecated("Use the new Api")
+    @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")
     fun <T : Fhir3Resource> encryptResource(
             dataKey: GCKey,
             resource: T

--- a/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
@@ -48,6 +48,7 @@ interface RecordContract {
         fun <T : Fhir4Resource> fetchFhir4Records(userId: String, resourceType: Class<T>, annotations: List<String>, startDate: LocalDate?, endDate: LocalDate?, pageSize: Int, offset: Int): Single<List<Fhir4Record<T>>>
 
         fun countFhir3Records(type: Class<out Fhir3Resource>, userId: String, annotations: List<String>): Single<Int>
+        fun countFhir4Records(type: Class<out Fhir4Resource>, userId: String, annotations: List<String>): Single<Int>
 
         fun countAllFhir3Records(userId: String, annotations: List<String>): Single<Int>
     }

--- a/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
@@ -46,5 +46,9 @@ interface RecordContract {
         fun fetchDataRecords(userId: String, annotations: List<String>, startDate: LocalDate?, endDate: LocalDate?, pageSize: Int, offset: Int): Single<List<DataRecord<DataResource>>>
         fun <T : Fhir3Resource> fetchFhir3Records(userId: String, resourceType: Class<T>, annotations: List<String>, startDate: LocalDate?, endDate: LocalDate?, pageSize: Int, offset: Int): Single<List<Record<T>>>
         fun <T : Fhir4Resource> fetchFhir4Records(userId: String, resourceType: Class<T>, annotations: List<String>, startDate: LocalDate?, endDate: LocalDate?, pageSize: Int, offset: Int): Single<List<Fhir4Record<T>>>
+
+        fun countFhir3Records(type: Class<out Fhir3Resource>, userId: String, annotations: List<String>): Single<Int>
+
+        fun countAllFhir3Records(userId: String, annotations: List<String>): Single<Int>
     }
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
@@ -19,7 +19,6 @@ package care.data4life.sdk.tag
 import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.D4LException
 import java.io.IOException
-import kotlin.collections.HashMap
 
 typealias Tags = HashMap<String, String>
 
@@ -42,7 +41,7 @@ class TaggingContract {
         fun encryptTags(tags: Tags): MutableList<String>
 
         @Throws(IOException::class)
-        fun decryptTags(encryptedTags: List<String>):Tags
+        fun decryptTags(encryptedTags: List<String>): Tags
 
         @Throws(IOException::class)
         fun encryptAnnotations(annotations: List<String>): MutableList<String>

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
@@ -16,7 +16,6 @@
 
 package care.data4life.sdk.tag
 
-import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.D4LException
 import java.io.IOException
 
@@ -30,9 +29,7 @@ class TaggingContract {
                 oldTags: HashMap<String, String>?
         ): HashMap<String, String>
 
-        fun tagVersion(tags: Tags, version: FhirContract.FhirVersion)
-
-        fun getTagsFromType(resourceType: Class<Any>?): Tags
+        fun getTagsFromType(resourceType: Class<out Any>): Tags
 
     }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
@@ -16,9 +16,12 @@
 
 package care.data4life.sdk.tag
 
+import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.D4LException
 import java.io.IOException
 import kotlin.collections.HashMap
+
+typealias Tags = HashMap<String, String>
 
 class TaggingContract {
 
@@ -28,16 +31,18 @@ class TaggingContract {
                 oldTags: HashMap<String, String>?
         ): HashMap<String, String>
 
-        fun getTagFromType(resourceType: Class<Any>?): HashMap<String, String>
+        fun tagVersion(tags: Tags, version: FhirContract.FhirVersion)
+
+        fun getTagsFromType(resourceType: Class<Any>?): Tags
 
     }
 
     interface EncryptionService {
         @Throws(IOException::class)
-        fun encryptTags(tags: HashMap<String, String>): MutableList<String>
+        fun encryptTags(tags: Tags): MutableList<String>
 
         @Throws(IOException::class)
-        fun decryptTags(encryptedTags: List<String>): HashMap<String, String>
+        fun decryptTags(encryptedTags: List<String>):Tags
 
         @Throws(IOException::class)
         fun encryptAnnotations(annotations: List<String>): MutableList<String>

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
@@ -29,7 +29,6 @@ import care.data4life.sdk.tag.TaggingContract.Companion.TAG_UPDATED_BY_CLIENT
 import care.data4life.sdk.tag.TaggingContract.Companion.TAG_UPDATED_BY_PARTNER
 import care.data4life.sdk.wrapper.SdkFhirElementFactory
 import care.data4life.sdk.wrapper.WrapperContract
-import kotlin.collections.HashMap
 
 // TODO internal
 class TaggingService(
@@ -71,7 +70,7 @@ class TaggingService(
                     resource.resourceType,
                     oldTags
             ).also { tags -> tagVersion(tags, FhirContract.FhirVersion.FHIR_3) }
-            is Fhir4Resource ->  appendCommonDefaultTags(
+            is Fhir4Resource -> appendCommonDefaultTags(
                     resource.resourceType,
                     oldTags
             ).also { tags -> tagVersion(tags, FhirContract.FhirVersion.FHIR_4) }
@@ -86,7 +85,7 @@ class TaggingService(
             tags: Tags,
             version: FhirContract.FhirVersion
     ) {
-        if(version == FhirContract.FhirVersion.UNKNOWN) {
+        if (version == FhirContract.FhirVersion.UNKNOWN) {
             tags[TAG_APPDATA_KEY] = TAG_APPDATA_VALUE
         } else {
             tags[TAG_FHIR_VERSION] = version.version

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
@@ -81,7 +81,7 @@ class TaggingService(
         }
     }
 
-    override fun tagVersion(
+    private fun tagVersion(
             tags: Tags,
             version: FhirContract.FhirVersion
     ) {
@@ -93,19 +93,18 @@ class TaggingService(
     }
 
     override fun getTagsFromType(
-            resourceType: Class<Any>?
+            resourceType: Class<out Any>
     ): HashMap<String, String> {
         return hashMapOf<String, String>().also { tags ->
-            if (resourceType == null) {
-                tags[TAG_APPDATA_KEY] = TAG_APPDATA_VALUE
-            } else {
+            val version = fhirElementFactory.resolveFhirVersion(resourceType)
+            tagVersion(tags, version)
+
+            if (version != FhirContract.FhirVersion.UNKNOWN) {
                 fhirElementFactory.getFhirTypeForClass(resourceType).also { resourceTagValue ->
                     if(resourceTagValue is String) {
                         tags[TAG_RESOURCE_TYPE] = resourceTagValue
                     }
                 }
-
-                tags[TAG_FHIR_VERSION] = fhirElementFactory.resolveFhirVersion(resourceType).version
             }
         }
     }

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
@@ -108,7 +108,5 @@ class TaggingService(
                 tags[TAG_FHIR_VERSION] = fhirElementFactory.resolveFhirVersion(resourceType).version
             }
         }
-
-        return tags.also { currentTags -> tagVersion(currentTags, version) }
     }
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/SdkFhirParser.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/SdkFhirParser.kt
@@ -18,9 +18,9 @@ internal object SdkFhirParser : WrapperContract.FhirParser {
     }
 
     override fun toFhir4(resourceType: String, source: String): Fhir4Resource {
-        val clazz = fhirElement.getFhir4ClassForType(resourceType)!!
+        val clazz = fhirElement.getFhir4ClassForType(resourceType)
 
-        return fhir4Parser.toFhir(clazz, source)
+        return fhir4Parser.toFhir(clazz!!, source)
     }
 
     override fun fromResource(resource: Any): String? {

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsIntegration.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsIntegration.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk
+
+import care.data4life.fhir.stu3.model.DocumentReference
+import care.data4life.sdk.attachment.AttachmentService
+import care.data4life.sdk.fhir.FhirService
+import care.data4life.sdk.tag.TagEncryptionService
+import care.data4life.sdk.tag.TaggingService
+import com.google.common.truth.Truth
+import io.mockk.every
+import io.mockk.mockk
+import io.reactivex.Single
+import org.junit.Before
+import org.junit.Test
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+class RecordServiceCountRecordsIntegration : RecordServiceIntegrationBase() {
+    @Before
+    fun setUp() {
+        apiService = mockk()
+        cryptoService = mockk()
+        fileService = mockk()
+        imageResizer = mockk()
+        errorHandler = mockk()
+
+        recordService = RecordService(
+                RecordServiceTestBase.PARTNER_ID,
+                RecordServiceTestBase.ALIAS,
+                apiService,
+                TagEncryptionService(
+                        cryptoService
+                ),
+                TaggingService(CLIENT_ID),
+                FhirService(
+                        cryptoService
+                ),
+                AttachmentService(
+                        fileService,
+                        imageResizer
+                ),
+                cryptoService,
+                errorHandler
+        )
+
+        dataKey = mockk()
+        attachmentKey = mockk()
+        tagEncryptionKey = mockk()
+        commonKey = mockk()
+        encryptedDataKey = mockk()
+        encryptedAttachmentKey = mockk()
+    }
+
+    private fun encryptTagsAndAnnotations(
+            tags: Map<String, String>,
+            annotations: Map<String, String> = mapOf()
+    ) {
+        // encrypt tags
+        every { cryptoService.fetchTagEncryptionKey() } returns tagEncryptionKey
+        every {
+            cryptoService.symEncrypt(tagEncryptionKey, eq(
+                    tags["resourcetype"]!!.toByteArray()
+            ), IV)
+        } returns tags["resourcetype"]!!.toByteArray()
+        every {
+            cryptoService.symEncrypt(tagEncryptionKey, eq(
+                    tags["fhirversion"]!!.toByteArray()
+            ), IV)
+        } returns tags["fhirversion"]!!.toByteArray()
+
+        // encrypt annotations
+        if (annotations.isNotEmpty()) {
+            every {
+                cryptoService.symEncrypt(tagEncryptionKey, eq(
+                        annotations["wow"]!!.toByteArray()
+                ), IV)
+            } returns annotations["wow"]!!.toByteArray()
+            every {
+                cryptoService.symEncrypt(tagEncryptionKey, eq(
+                        annotations["it"]!!.toByteArray()
+                ), IV)
+            } returns annotations["it"]!!.toByteArray()
+            every {
+                cryptoService.symEncrypt(tagEncryptionKey, eq(
+                        annotations["works"]!!.toByteArray()
+                ), IV)
+            } returns annotations["works"]!!.toByteArray()
+        }
+    }
+
+    @Test
+    fun `Given, countRecords is called with a type and UserId, it returns the amount of Records`() {
+        val encodedEncryptedVersion = "ZmhpcnZlcnNpb249MyUyZTAlMmUx"
+        val encodedEncryptedResourceType = "cmVzb3VyY2V0eXBlPWRvY3VtZW50cmVmZXJlbmNl"
+
+        val tags = mapOf(
+                "partner" to "partner=${PARTNER_ID}".toLowerCase(),
+                "client" to "client=${
+                    URLEncoder.encode(CLIENT_ID.toLowerCase(), StandardCharsets.UTF_8.displayName())
+                }",
+                "fhirversion" to "fhirversion=${
+                    "3.0.1".replace(".", "%2e")
+                }",
+                "resourcetype" to "resourcetype=documentreference"
+        )
+
+        encryptTagsAndAnnotations(tags)
+
+        every {
+            apiService.getCount(
+                    ALIAS,
+                    USER_ID,
+                    listOf(encodedEncryptedVersion, encodedEncryptedResourceType)
+            )
+        } returns Single.just(23)
+
+        // When
+        val result = (recordService as RecordService).countRecords(
+                DocumentReference::class.java,
+                USER_ID
+        ).blockingGet()
+
+        // Then
+        Truth.assertThat(result).isEqualTo(23)
+    }
+
+    @Test
+    fun `Given, countRecords is called without a type, UserId and Annotations, it returns the amount of Records`() {
+        val encodedEncryptedVersion = "ZmhpcnZlcnNpb249MyUyZTAlMmUx"
+
+        val annotations = mapOf(
+                "wow" to "custom=wow",
+                "it" to "custom=it",
+                "works" to "custom=works"
+        )
+
+        val tags = mapOf(
+                "partner" to "partner=${PARTNER_ID}".toLowerCase(),
+                "client" to "client=${
+                    URLEncoder.encode(CLIENT_ID.toLowerCase(), StandardCharsets.UTF_8.displayName())
+                }",
+                "fhirversion" to "fhirversion=${
+                    "3.0.1".replace(".", "%2e")
+                }",
+                "resourcetype" to "resourcetype=documentreference"
+        )
+
+        encryptTagsAndAnnotations(tags, annotations)
+
+        every {
+            apiService.getCount(
+                    ALIAS,
+                    USER_ID,
+                    listOf(
+                            encodedEncryptedVersion,
+                            "Y3VzdG9tPXdvdw==",
+                            "Y3VzdG9tPWl0",
+                            "Y3VzdG9tPXdvcmtz"
+                    )
+            )
+        } returns Single.just(23)
+
+        // When
+        val result = (recordService as RecordService).countRecords(
+                null,
+                USER_ID,
+                annotations.keys.toList()
+        ).blockingGet()
+
+        // Then
+        Truth.assertThat(result).isEqualTo(23)
+    }
+
+    @Test
+    fun `Given, countFhir3Records is called with a type, UserId and Annotations, it returns the amount of Records`() {
+        val encodedEncryptedVersion = "ZmhpcnZlcnNpb249MyUyZTAlMmUx"
+        val encodedEncryptedResourceType = "cmVzb3VyY2V0eXBlPWRvY3VtZW50cmVmZXJlbmNl"
+
+        val annotations = mapOf(
+                "wow" to "custom=wow",
+                "it" to "custom=it",
+                "works" to "custom=works"
+        )
+
+        val tags = mapOf(
+                "partner" to "partner=${PARTNER_ID}".toLowerCase(),
+                "client" to "client=${
+                    URLEncoder.encode(CLIENT_ID.toLowerCase(), StandardCharsets.UTF_8.displayName())
+                }",
+                "fhirversion" to "fhirversion=${
+                    "3.0.1".replace(".", "%2e")
+                }",
+                "resourcetype" to "resourcetype=documentreference"
+        )
+
+        encryptTagsAndAnnotations(tags, annotations)
+
+        every {
+            apiService.getCount(
+                    ALIAS,
+                    USER_ID,
+                    listOf(
+                            encodedEncryptedVersion,
+                            encodedEncryptedResourceType,
+                            "Y3VzdG9tPXdvdw==",
+                            "Y3VzdG9tPWl0",
+                            "Y3VzdG9tPXdvcmtz"
+                    )
+            )
+        } returns Single.just(23)
+
+        // When
+        val result = (recordService as RecordService).countFhir3Records(
+                DocumentReference::class.java,
+                USER_ID,
+                annotations.keys.toList()
+        ).blockingGet()
+
+        // Then
+        Truth.assertThat(result).isEqualTo(23)
+    }
+
+    @Test
+    fun `Given, countAllFhir3Records is called with a UserId and Annotations, it returns the amount of Records`() {
+        val encodedEncryptedVersion = "ZmhpcnZlcnNpb249MyUyZTAlMmUx"
+
+        val annotations = mapOf(
+                "wow" to "custom=wow",
+                "it" to "custom=it",
+                "works" to "custom=works"
+        )
+
+        val tags = mapOf(
+                "partner" to "partner=${PARTNER_ID}".toLowerCase(),
+                "client" to "client=${
+                    URLEncoder.encode(CLIENT_ID.toLowerCase(), StandardCharsets.UTF_8.displayName())
+                }",
+                "fhirversion" to "fhirversion=${
+                    "3.0.1".replace(".", "%2e")
+                }",
+                "resourcetype" to "resourcetype=documentreference"
+        )
+
+        encryptTagsAndAnnotations(tags, annotations)
+
+        every {
+            apiService.getCount(
+                    ALIAS,
+                    USER_ID,
+                    listOf(
+                            encodedEncryptedVersion,
+                            "Y3VzdG9tPXdvdw==",
+                            "Y3VzdG9tPWl0",
+                            "Y3VzdG9tPXdvcmtz"
+                    )
+            )
+        } returns Single.just(23)
+
+        // When
+        val result = (recordService as RecordService).countAllFhir3Records(
+                USER_ID,
+                annotations.keys.toList()
+        ).blockingGet()
+
+        // Then
+        Truth.assertThat(result).isEqualTo(23)
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -155,23 +155,14 @@ class RecordServiceCountRecordsTest {
 
     @Test
     @Throws(InterruptedException::class, IOException::class)
-    fun `Given, countAllFhir3Records is called, with a UserId and Annotations, it returns amount of occurrences`() {
+    fun `Given, countAllFhir3Records is called, with a UserId and Annotations, it delegates to the call to countFhir3Records with a Fhir3Resource as typeResource`() {
         // Given
         val expected = 42
         val annotations: List<String> = mockk()
-        val emptyTags = slot<HashMap<String, String>>()
-        val markedTags = hashMapOf("mark" to "mark")
 
         every {
-            taggingService.tagVersion(capture(emptyTags), FhirContract.FhirVersion.FHIR_3)
-        } answers {
-            assertTrue(emptyTags.captured.isEmpty())
-            emptyTags.captured["mark"] = "mark"
-        }
-        every { tagEncryptionService.encryptTags(markedTags) } returns encryptedTags
-        every { tagEncryptionService.encryptAnnotations(annotations) } returns encryptedAnnotations
-        every { encryptedTags.addAll(encryptedAnnotations) } returns true
-        every { apiService.getCount(ALIAS, USER_ID, encryptedTags) } returns Single.just(expected)
+            recordService.countFhir3Records(Fhir3Resource::class.java, USER_ID, annotations)
+        } returns Single.just(expected)
 
         // When
         val observer = recordService.countAllFhir3Records(
@@ -190,11 +181,7 @@ class RecordServiceCountRecordsTest {
                 expected = expected,
                 actual = result
         )
-        verify(exactly = 1) { taggingService.tagVersion(markedTags, FhirContract.FhirVersion.FHIR_3) }
-        verify(exactly = 1) { tagEncryptionService.encryptTags(markedTags) }
-        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(annotations) }
-        verify(exactly = 1) { encryptedTags.addAll(encryptedAnnotations) }
-        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, encryptedTags) }
+        verify(exactly = 1) { recordService.countFhir3Records(Fhir3Resource::class.java, USER_ID, annotations) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -35,6 +35,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.IOException
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class RecordServiceCountRecordsTest {
     private lateinit var recordService: RecordService
@@ -164,9 +165,7 @@ class RecordServiceCountRecordsTest {
         every {
             taggingService.tagVersion(capture(emptyTags), FhirContract.FhirVersion.FHIR_3)
         } answers {
-            if (emptyTags.captured.isNotEmpty()) {
-                throw RuntimeException("Expected empty tags")
-            }
+            assertTrue(emptyTags.captured.isEmpty())
             emptyTags.captured["mark"] = "mark"
         }
         every { tagEncryptionService.encryptTags(markedTags) } returns encryptedTags

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -17,8 +17,8 @@
 package care.data4life.sdk
 
 import care.data4life.fhir.stu3.model.CarePlan
+import care.data4life.fhir.stu3.model.Patient
 import care.data4life.sdk.RecordServiceTestBase.Companion.ALIAS
-import care.data4life.sdk.RecordServiceTestBase.Companion.ANNOTATIONS
 import care.data4life.sdk.RecordServiceTestBase.Companion.PARTNER_ID
 import care.data4life.sdk.RecordServiceTestBase.Companion.USER_ID
 import care.data4life.sdk.attachment.AttachmentContract
@@ -26,13 +26,13 @@ import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.tag.TaggingContract
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import io.reactivex.Single
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
-import java.util.*
 import kotlin.test.assertEquals
 
 class RecordServiceCountRecordsTest {
@@ -46,7 +46,7 @@ class RecordServiceCountRecordsTest {
     private lateinit var errorHandler: SdkContract.ErrorHandler
     private lateinit var tags: HashMap<String, String>
     private lateinit var encryptedTags: MutableList<String>
-    private val defaultAnnotation: MutableList<String> = mutableListOf()
+    private val defaultAnnotations = listOf<String>()
     private lateinit var encryptedAnnotations: MutableList<String>
 
     @Before
@@ -77,101 +77,23 @@ class RecordServiceCountRecordsTest {
 
     @Test
     @Throws(InterruptedException::class, IOException::class)
-    fun `Given, countRecords is called with a DomainResource and a UserId, it returns amount of occurrences`() {
+    fun `Given, countFhir3Records is called with a Fhir3Resource, a UserId and Annotations, it returns amount of occurrences`() {
         // Given
-        val response = 42
-
-        every { apiService.getCount(ALIAS, USER_ID, null) } returns Single.just(response)
-
-        // When
-        val observer = recordService.countRecords(null, USER_ID).test().await()
-
-        // Then
-        val result = observer
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
-
-        assertEquals(
-                expected = response,
-                actual = result
-        )
-        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, null) }
-    }
-
-    @Test
-    @Throws(InterruptedException::class, IOException::class)
-    fun `Given, countRecords is called with a DomainResource, a UserId and a Tag, it returns amount of occurrences`() {
-        // Given
-        val response = 42
+        val expected = 42
+        val annotations: List<String> = mockk()
 
         every { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
-        every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
-        every { encryptedTags.addAll(defaultAnnotation) } returns true
-        every { apiService.getCount(ALIAS, USER_ID, encryptedTags) } returns Single.just(response)
-
-        // When
-        val observer = recordService.countRecords(CarePlan::class.java, USER_ID).test().await()
-
-        // Then
-        val result = observer
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
-
-        assertEquals(
-                expected = response,
-                actual = result
-        )
-        verify(exactly = 1) { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) }
-        verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
-        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
-        verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
-        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, encryptedTags) }
-    }
-
-    @Test
-    @Throws(InterruptedException::class)
-    fun `Given, countRecords is called with a DomainResource, a UserId and Annotations, it returns amount of occurrences`() {
-        // Given
-        val response = 42
-
-        every { apiService.getCount(ALIAS, USER_ID, null) } returns Single.just(response)
-
-        // When
-        val observer = recordService.countRecords(null, USER_ID, ANNOTATIONS).test().await()
-
-        // Then
-        val result = observer
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
-
-        assertEquals(
-                expected = response,
-                actual = result
-        )
-        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, null) }
-    }
-
-    @Test
-    @Throws(InterruptedException::class, IOException::class)
-    fun `Given, countRecords is called with a DomainResource, a UserId, a Tag and Annotations, it returns amount of occurrences`() {
-        // Given
-        val response = 42
-
-        every { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) } returns tags
-        every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
-        every { tagEncryptionService.encryptAnnotations(ANNOTATIONS) } returns encryptedAnnotations
+        every { tagEncryptionService.encryptAnnotations(annotations) } returns encryptedAnnotations
         every { encryptedTags.addAll(encryptedAnnotations) } returns true
-        every { apiService.getCount(ALIAS, USER_ID, encryptedTags) } returns Single.just(response)
+        every { apiService.getCount(ALIAS, USER_ID, encryptedTags) } returns Single.just(expected)
 
         // When
-        val observer = recordService.countRecords(CarePlan::class.java, USER_ID, ANNOTATIONS).test().await()
+        val observer = recordService.countFhir3Records(
+                CarePlan::class.java,
+                USER_ID,
+                annotations
+        ).test().await()
 
         // Then
         val result = observer
@@ -181,13 +103,217 @@ class RecordServiceCountRecordsTest {
                 .values()[0]
 
         assertEquals(
-                expected = response,
+                expected = expected,
                 actual = result
         )
         verify(exactly = 1) { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
-        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(ANNOTATIONS) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(annotations) }
         verify(exactly = 1) { encryptedTags.addAll(encryptedAnnotations) }
         verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, encryptedTags) }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class)
+    fun `Given, countAllFhir3Records is called, with a UserId and Annotations, it returns amount of occurrences`() {
+        // Given
+        val expected = 42
+        val annotations: List<String> = mockk()
+        val emptyTags = slot<HashMap<String, String>>()
+        val markedTags = hashMapOf("mark" to "mark")
+
+        every {
+            taggingService.tagVersion(capture(emptyTags), FhirContract.FhirVersion.FHIR_3)
+        } answers {
+            if (emptyTags.captured.isNotEmpty()) {
+                throw RuntimeException("Expected empty tags")
+            }
+            emptyTags.captured["mark"] = "mark"
+        }
+        every { tagEncryptionService.encryptTags(markedTags) } returns encryptedTags
+        every { tagEncryptionService.encryptAnnotations(annotations) } returns encryptedAnnotations
+        every { encryptedTags.addAll(encryptedAnnotations) } returns true
+        every { apiService.getCount(ALIAS, USER_ID, encryptedTags) } returns Single.just(expected)
+
+        // When
+        val observer = recordService.countAllFhir3Records(
+                USER_ID,
+                annotations
+        ).test().await()
+
+        // Then
+        val result = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = expected,
+                actual = result
+        )
+        verify(exactly = 1) { taggingService.tagVersion(markedTags, FhirContract.FhirVersion.FHIR_3) }
+        verify(exactly = 1) { tagEncryptionService.encryptTags(markedTags) }
+        verify(exactly = 1) { tagEncryptionService.encryptAnnotations(annotations) }
+        verify(exactly = 1) { encryptedTags.addAll(encryptedAnnotations) }
+        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, encryptedTags) }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class)
+    fun `Given, countRecords is called, with a UserId and resourceType, it delegate its call to countFhir3Records`() {
+        // Given
+        val resourceType = Patient::class.java
+        val expected = 23
+
+        every {
+            recordService.countFhir3Records(
+                    resourceType,
+                    USER_ID,
+                    defaultAnnotations
+            )
+        } returns Single.just(expected)
+
+        val observer = recordService.countRecords(
+                resourceType,
+                USER_ID
+        ).test().await()
+
+        // Then
+        val result = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = expected,
+                actual = result
+        )
+        verify(exactly = 1) {
+            recordService.countFhir3Records(
+                    resourceType,
+                    USER_ID,
+                    defaultAnnotations
+            )
+        }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class)
+    fun `Given, countRecords is called, with a UserId, resourceType and Annotations, it delegate its call to countFhir3Records`() {
+        // Given
+        val resourceType = Patient::class.java
+        val expected = 23
+        val annotations: List<String> = mockk()
+
+        every {
+            recordService.countFhir3Records(
+                    resourceType,
+                    USER_ID,
+                    annotations
+            )
+        } returns Single.just(expected)
+
+        val observer = recordService.countRecords(
+                resourceType,
+                USER_ID,
+                annotations
+        ).test().await()
+
+        // Then
+        val result = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = expected,
+                actual = result
+        )
+        verify(exactly = 1) {
+            recordService.countFhir3Records(
+                    resourceType,
+                    USER_ID,
+                    annotations
+            )
+        }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class)
+    fun `Given, countRecords is called, with a null as resourceType and a UserId, it delegate its call to countAllFhir3Records`() {
+        // Given
+        val expected = 23
+
+        every {
+            recordService.countAllFhir3Records(
+                    USER_ID,
+                    defaultAnnotations
+            )
+        } returns Single.just(expected)
+
+        val observer = recordService.countRecords(
+                null,
+                USER_ID
+        ).test().await()
+
+        // Then
+        val result = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = expected,
+                actual = result
+        )
+        verify(exactly = 1) {
+            recordService.countAllFhir3Records(
+                    USER_ID,
+                    defaultAnnotations
+            )
+        }
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class)
+    fun `Given, countRecords is called, with a null as resourceType, a UserId and Annotations, it delegate its call to countAllFhir3Records`() {
+        // Given
+        val expected = 23
+        val annotations: List<String> = mockk()
+
+        every {
+            recordService.countAllFhir3Records(
+                    USER_ID,
+                    annotations
+            )
+        } returns Single.just(expected)
+
+        val observer = recordService.countRecords(
+                null,
+                USER_ID,
+                annotations
+        ).test().await()
+
+        // Then
+        val result = observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValueCount(1)
+                .values()[0]
+
+        assertEquals(
+                expected = expected,
+                actual = result
+        )
+        verify(exactly = 1) {
+            recordService.countAllFhir3Records(
+                    USER_ID,
+                    annotations
+            )
+        }
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -106,7 +106,7 @@ class RecordServiceCountRecordsTest {
         // Given
         val response = 42
 
-        every { taggingService.getTagFromType(CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { encryptedTags.addAll(defaultAnnotation) } returns true
@@ -126,7 +126,7 @@ class RecordServiceCountRecordsTest {
                 expected = response,
                 actual = result
         )
-        verify(exactly = 1) { taggingService.getTagFromType(CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
         verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
@@ -164,7 +164,7 @@ class RecordServiceCountRecordsTest {
         // Given
         val response = 42
 
-        every { taggingService.getTagFromType(CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(ANNOTATIONS) } returns encryptedAnnotations
         every { encryptedTags.addAll(encryptedAnnotations) } returns true
@@ -184,7 +184,7 @@ class RecordServiceCountRecordsTest {
                 expected = response,
                 actual = result
         )
-        verify(exactly = 1) { taggingService.getTagFromType(CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(ANNOTATIONS) }
         verify(exactly = 1) { encryptedTags.addAll(encryptedAnnotations) }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
@@ -314,7 +314,7 @@ class RecordServiceFetchRecordsTest {
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { encryptedTags.addAll(defaultAnnotation) } returns true
@@ -375,7 +375,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record2,
                 actual = fetched[1]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
         verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
@@ -418,7 +418,7 @@ class RecordServiceFetchRecordsTest {
 
         every { RecordService.formatDate(startDate) } returns start
         every { RecordService.formatDate(endDate) } returns end
-        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { encryptedTags.addAll(defaultAnnotation) } returns true
@@ -480,7 +480,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record2,
                 actual = fetched[1]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
         verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
@@ -519,7 +519,7 @@ class RecordServiceFetchRecordsTest {
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { encryptedTags.addAll(defaultAnnotation) } returns true
@@ -575,7 +575,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record1,
                 actual = fetched[0]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
         verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
@@ -611,7 +611,7 @@ class RecordServiceFetchRecordsTest {
 
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
@@ -670,7 +670,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record1,
                 actual = fetched[0]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { apiService.fetchRecords(
                 ALIAS,
@@ -703,7 +703,7 @@ class RecordServiceFetchRecordsTest {
 
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
@@ -757,7 +757,7 @@ class RecordServiceFetchRecordsTest {
                 expected = 0,
                 actual = fetched.size
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { apiService.fetchRecords(
                 ALIAS,
@@ -790,7 +790,7 @@ class RecordServiceFetchRecordsTest {
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { encryptedTags.addAll(defaultAnnotation) } returns true
@@ -852,7 +852,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record2,
                 actual = fetched[1]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
         verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
@@ -895,7 +895,7 @@ class RecordServiceFetchRecordsTest {
 
         every { RecordService.formatDate(startDate) } returns start
         every { RecordService.formatDate(endDate) } returns end
-        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { encryptedTags.addAll(defaultAnnotation) } returns true
@@ -958,7 +958,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record2,
                 actual = fetched[1]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
         verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
@@ -997,7 +997,7 @@ class RecordServiceFetchRecordsTest {
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { encryptedTags.addAll(defaultAnnotation) } returns true
@@ -1054,7 +1054,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record1,
                 actual = fetched[0]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { tagEncryptionService.encryptAnnotations(defaultAnnotation) }
         verify(exactly = 1) { encryptedTags.addAll(defaultAnnotation) }
@@ -1090,7 +1090,7 @@ class RecordServiceFetchRecordsTest {
 
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
@@ -1149,7 +1149,7 @@ class RecordServiceFetchRecordsTest {
                 expected = record1,
                 actual = fetched[0]
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { apiService.fetchRecords(
                 ALIAS,
@@ -1182,7 +1182,7 @@ class RecordServiceFetchRecordsTest {
 
         mockkObject(RecordMapper)
 
-        every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
         every { tagEncryptionService.encryptAnnotations(annotations) } returns annotations.toMutableList()
@@ -1236,7 +1236,7 @@ class RecordServiceFetchRecordsTest {
                 expected = 0,
                 actual = fetched.size
         )
-        verify(exactly = 1) { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) }
+        verify(exactly = 1) { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) }
         verify(exactly = 1) { tagEncryptionService.encryptTags(tags) }
         verify(exactly = 1) { apiService.fetchRecords(
                 ALIAS,

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceIntegration.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceIntegration.kt
@@ -16,7 +16,6 @@
 
 package care.data4life.sdk
 
-import care.data4life.fhir.stu3.model.DocumentReference
 import care.data4life.sdk.attachment.AttachmentService
 import care.data4life.sdk.fhir.Fhir3Attachment
 import care.data4life.sdk.fhir.FhirService
@@ -220,50 +219,5 @@ class RecordServiceIntegration : RecordServiceIntegrationBase() {
             // Then
             Truth.assertThat(e).isInstanceOf(ClassCastException::class.java)
         }
-    }
-
-    @Test
-    fun `Given, countRecords is called with its appropriate parameter, it returns the amount of Records`() {
-        val encodedEncryptedVersion = "ZmhpcnZlcnNpb249MyUyZTAlMmUx"
-        val encodedEncryptedResourceType = "cmVzb3VyY2V0eXBlPWRvY3VtZW50cmVmZXJlbmNl"
-
-        val tags = mapOf(
-                "partner" to "partner=$PARTNER_ID".toLowerCase(),
-                "client" to "client=${
-                    URLEncoder.encode(CLIENT_ID.toLowerCase(), StandardCharsets.UTF_8.displayName())
-                }",
-                "fhirversion" to "fhirversion=${
-                    "3.0.1".replace(".", "%2e")
-                }",
-                "resourcetype" to "resourcetype=documentreference"
-        )
-
-        // encrypt tags
-        every { cryptoService.fetchTagEncryptionKey() } returns tagEncryptionKey
-        every {
-            cryptoService.symEncrypt(tagEncryptionKey, eq(
-                    tags["resourcetype"]!!.toByteArray()
-            ), IV)
-        } returns tags["resourcetype"]!!.toByteArray()
-        every {
-            cryptoService.symEncrypt(tagEncryptionKey, eq(
-                    tags["fhirversion"]!!.toByteArray()
-            ), IV)
-        } returns tags["fhirversion"]!!.toByteArray()
-
-        every { apiService.getCount(
-                ALIAS,
-                USER_ID,
-                listOf(encodedEncryptedVersion, encodedEncryptedResourceType)
-        ) } returns Single.just(23)
-
-        // When
-        val result = (recordService as RecordService).countRecords(
-                DocumentReference::class.java,
-                USER_ID
-        ).blockingGet()
-
-        // Then
-        Truth.assertThat(result).isEqualTo(23)
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/fhir/FhirRecordClientTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/fhir/FhirRecordClientTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.fhir
+
+import care.data4life.sdk.auth.UserService
+import care.data4life.sdk.call.CallHandler
+import care.data4life.sdk.call.Callback
+import care.data4life.sdk.call.Task
+import care.data4life.sdk.record.RecordContract
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.reactivex.Single
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class FhirRecordClientTest {
+    @Test
+    fun `Given count is called, with a resourceType, Annotations and a Callback it returns its Task`() {
+        // Given
+        val userService: UserService = mockk()
+        val recordService: RecordContract.Service = mockk()
+        val callHandler: CallHandler = mockk()
+        val client = Fhir4RecordClient(
+                userService,
+                recordService,
+                callHandler
+        )
+
+        val resourceType = Fhir4Resource::class.java
+        val annotations: List<String> = mockk()
+        val callback: Callback<Int> = mockk()
+
+        val userId = "Potato"
+        val expectedAmount = 23
+        val amount = Single.just(23)
+        val expected: Task = mockk()
+        val capturedAmount = slot<Single<Int>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.uID } returns Single.just(userId)
+        every {
+            recordService.countFhir4Records(resourceType, userId, annotations)
+        } returns amount
+        every {
+            callHandler.executeSingle(capture(capturedAmount), callback)
+        } answers {
+            val actualAmount = capturedAmount.captured.blockingGet()
+            assertEquals(
+                    expected = expectedAmount,
+                    actual = actualAmount
+            )
+            expected
+        }
+
+        // When
+        val actual = client.count(resourceType, annotations, callback)
+
+        // Then
+        assertSame(
+                expected = expected,
+                actual = actual
+        )
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
@@ -157,7 +157,7 @@ class TaggingServiceTest {
     }
 
     @Test
-    fun `Given, getTagFromType is called with a Class of a Fhir3Resource, it returns a Map, which contains TAG_RESOURCE_TYPE and TAG_FHIR_VERSION for the given type`() {
+    fun `Given, getTagsFromType is called with a Class of a Fhir3Resource, it returns a Map, which contains TAG_RESOURCE_TYPE and TAG_FHIR_VERSION for the given type`() {
         // Given
         val type: Patient = mockk()
         val resourceType = "fhir4Resource"
@@ -183,7 +183,7 @@ class TaggingServiceTest {
     }
 
     @Test
-    fun `Given, getTagFromType is called with a Class of a Fhir3Resource, it does not set the TAG_RESOURCE_TYPE but the TAG_FHIR_VERSION, if the resource was not determined`() {
+    fun `Given, getTagFromsType is called with a Class of a Fhir3Resource, it does not set the TAG_RESOURCE_TYPE but the TAG_FHIR_VERSION, if the resource was not determined`() {
         // Given
         val type: Fhir3Resource = mockk()
         val resourceType = null
@@ -193,7 +193,7 @@ class TaggingServiceTest {
         every { SdkFhirElementFactory.resolveFhirVersion(Fhir3Resource::class.java) } returns FhirContract.FhirVersion.FHIR_3
         // When
         @Suppress("UNCHECKED_CAST")
-        val result = taggingService.getTagFromType(type::class.java as Class<Any>)
+        val result = taggingService.getTagsFromType(type::class.java as Class<Any>)
 
         // Then
         assertEquals(1, result.size)
@@ -208,7 +208,7 @@ class TaggingServiceTest {
     }
 
     @Test
-    fun `Given, getTagFromType is called with a Class of a Fhir4Resource, it returns a Map, which contains TAG_RESOURCE_TYPE and TAG_FHIR_VERSION for the given type`() {
+    fun `Given, getTagsFromType is called with a Class of a Fhir4Resource, it returns a Map, which contains TAG_RESOURCE_TYPE and TAG_FHIR_VERSION for the given type`() {
         // Given
         val type: R4Patient = mockk()
         val resourceType = "fhir4Resource"
@@ -234,7 +234,7 @@ class TaggingServiceTest {
     }
 
     @Test
-    fun `Given, getTagFromType is called with a Class of a Fhir4Resource, it does not set the TAG_RESOURCE_TYPE but the TAG_FHIR_VERSION, if the resource was not determined`() {
+    fun `Given, getTagsFromType is called with a Class of a Fhir4Resource, it does not set the TAG_RESOURCE_TYPE but the TAG_FHIR_VERSION, if the resource was not determined`() {
         // Given
         val type: Fhir4Resource = mockk()
         val resourceType = null
@@ -244,7 +244,7 @@ class TaggingServiceTest {
         every { SdkFhirElementFactory.resolveFhirVersion(Fhir4Resource::class.java) } returns FhirContract.FhirVersion.FHIR_4
         // When
         @Suppress("UNCHECKED_CAST")
-        val result = taggingService.getTagFromType(type::class.java as Class<Any>)
+        val result = taggingService.getTagsFromType(type::class.java as Class<Any>)
 
         // Then
         assertEquals(1, result.size)
@@ -259,7 +259,7 @@ class TaggingServiceTest {
     }
 
     @Test
-    fun `Given, getTagFromType is called with null, it returns a Map, which contains TAG_APPDATA_KEY`() {//getTagFromType_shouldReturnEmptyList_whenResourceTypeNull
+    fun `Given, getTagsFromType is called with null, it returns a Map, which contains TAG_APPDATA_KEY`() {//getTagFromType_shouldReturnEmptyList_whenResourceTypeNull
         // When
         val result = taggingService.getTagsFromType(null)
 

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
@@ -261,24 +261,19 @@ class TaggingServiceTest {
     @Test
     fun `Given, getTagsFromType is called with a Class of a non Resource, it returns a Map, which contains TAG_APPDATA_KEY`() {
         // Given
-        val type: Fhir4Resource = mockk()
-        val resourceType = null
+        val type: DataResource = mockk()
 
         mockkObject(SdkFhirElementFactory)
-        every { SdkFhirElementFactory.getFhirTypeForClass(Fhir4Resource::class.java) } returns resourceType
-        every { SdkFhirElementFactory.resolveFhirVersion(Fhir4Resource::class.java) } returns FhirContract.FhirVersion.FHIR_4
+        every { SdkFhirElementFactory.resolveFhirVersion(DataResource::class.java) } returns FhirContract.FhirVersion.UNKNOWN
         // When
         @Suppress("UNCHECKED_CAST")
         val result = taggingService.getTagsFromType(type::class.java as Class<Any>)
 
         // Then
         assertEquals(1, result.size)
-        assertFalse(result.containsKey(TAG_RESOURCE_TYPE))
-        assertTrue(result.containsKey(TAG_FHIR_VERSION))
-        assertEquals(FhirContract.FhirVersion.FHIR_4.version, result[TAG_FHIR_VERSION])
+        assertTrue(result.containsKey(TAG_APPDATA_KEY))
 
-        verify(exactly = 1) { SdkFhirElementFactory.getFhirTypeForClass(Fhir4Resource::class.java) }
-        verify(exactly = 1) { SdkFhirElementFactory.resolveFhirVersion(Fhir4Resource::class.java) }
+        verify(exactly = 1) { SdkFhirElementFactory.resolveFhirVersion(DataResource::class.java) }
 
         unmockkObject(SdkFhirElementFactory)
     }

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
@@ -259,50 +259,28 @@ class TaggingServiceTest {
     }
 
     @Test
-    fun `Given, getTagsFromType is called with null, it returns a Map, which contains TAG_APPDATA_KEY`() {//getTagFromType_shouldReturnEmptyList_whenResourceTypeNull
+    fun `Given, getTagsFromType is called with a Class of a non Resource, it returns a Map, which contains TAG_APPDATA_KEY`() {
+        // Given
+        val type: Fhir4Resource = mockk()
+        val resourceType = null
+
+        mockkObject(SdkFhirElementFactory)
+        every { SdkFhirElementFactory.getFhirTypeForClass(Fhir4Resource::class.java) } returns resourceType
+        every { SdkFhirElementFactory.resolveFhirVersion(Fhir4Resource::class.java) } returns FhirContract.FhirVersion.FHIR_4
         // When
-        val result = taggingService.getTagsFromType(null)
+        @Suppress("UNCHECKED_CAST")
+        val result = taggingService.getTagsFromType(type::class.java as Class<Any>)
 
         // Then
         assertEquals(1, result.size)
-        assertTrue(result.containsKey(TAG_APPDATA_KEY))
-        assertEquals(TAG_APPDATA_VALUE, result[TAG_APPDATA_KEY])
-    }
+        assertFalse(result.containsKey(TAG_RESOURCE_TYPE))
+        assertTrue(result.containsKey(TAG_FHIR_VERSION))
+        assertEquals(FhirContract.FhirVersion.FHIR_4.version, result[TAG_FHIR_VERSION])
 
-    @Test
-    fun `Given, tagVersion is called with FHIR_3 and a map, it adds the appropriate TAG_FHIR_VERSION field`() {
-        // Given
-        val map = hashMapOf<String, String>()
+        verify(exactly = 1) { SdkFhirElementFactory.getFhirTypeForClass(Fhir4Resource::class.java) }
+        verify(exactly = 1) { SdkFhirElementFactory.resolveFhirVersion(Fhir4Resource::class.java) }
 
-        // When
-        taggingService.tagVersion(map, FhirContract.FhirVersion.FHIR_3)
-
-        assertTrue(map.containsKey(TAG_FHIR_VERSION))
-        assertEquals(FhirContract.FhirVersion.FHIR_3.version, map[TAG_FHIR_VERSION])
-    }
-
-    @Test
-    fun `Given, tagVersion is called with FHIR_4 and a map, it adds the appropriate TAG_FHIR_VERSION field`() {
-        // Given
-        val map = hashMapOf<String, String>()
-
-        // When
-        taggingService.tagVersion(map, FhirContract.FhirVersion.FHIR_4)
-
-        assertTrue(map.containsKey(TAG_FHIR_VERSION))
-        assertEquals(FhirContract.FhirVersion.FHIR_4.version, map[TAG_FHIR_VERSION])
-    }
-
-    @Test
-    fun `Given, tagVersion is called with UNKNOWN and a map, it adds the appropriate TAG_FHIR_VERSION field`() {
-        // Given
-        val map = hashMapOf<String, String>()
-
-        // When
-        taggingService.tagVersion(map, FhirContract.FhirVersion.UNKNOWN)
-
-        assertTrue(map.containsKey(TAG_APPDATA_KEY))
-        assertEquals(TAG_APPDATA_VALUE, map[TAG_APPDATA_KEY])
+        unmockkObject(SdkFhirElementFactory)
     }
 
     companion object {

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
@@ -52,7 +52,7 @@ class TaggingServiceTest {
         val result = taggingService.appendDefaultTags(resource, null)
 
         // Then
-        assertEquals(4, result.size.toLong())
+        assertEquals(4, result.size)
         assertTrue(result.containsKey(TAG_RESOURCE_TYPE))
         assertEquals(resource.resourceType, result[TAG_RESOURCE_TYPE])
         assertTrue(result.containsKey(TAG_CLIENT))
@@ -74,7 +74,7 @@ class TaggingServiceTest {
         val result = taggingService.appendDefaultTags(resource, null)
 
         // Then
-        assertEquals(4, result.size.toLong())
+        assertEquals(4, result.size)
         assertTrue(result.containsKey(TAG_RESOURCE_TYPE))
         assertEquals(resource.resourceType, result[TAG_RESOURCE_TYPE])
         assertTrue(result.containsKey(TAG_CLIENT))
@@ -95,7 +95,7 @@ class TaggingServiceTest {
         val result = taggingService.appendDefaultTags(resource, null)
 
         // Then
-        assertEquals(3, result.size.toLong())
+        assertEquals(3, result.size)
         assertFalse(result.containsKey(TAG_RESOURCE_TYPE))
         assertTrue(result.containsKey(TAG_CLIENT))
         assertEquals(CLIENT_ID, result[TAG_CLIENT])
@@ -119,7 +119,7 @@ class TaggingServiceTest {
         val result = taggingService.appendDefaultTags(type, existingTags)
 
         // Then
-        assertEquals(6, result.size.toLong())
+        assertEquals(6, result.size)
         assertTrue(result.containsKey("tag_1_key"))
         assertTrue(result.containsKey("tag_2_key"))
         assertTrue(result.containsKey(TAG_RESOURCE_TYPE))
@@ -144,7 +144,7 @@ class TaggingServiceTest {
         val result = taggingService.appendDefaultTags(type, existingTags)
 
         // Then
-        assertEquals(5, result.size.toLong())
+        assertEquals(5, result.size)
         assertTrue(result.containsKey(TAG_CLIENT))
         assertEquals(OTHER_CLIENT_ID, result[TAG_CLIENT])
         assertTrue(result.containsKey(TAG_UPDATED_BY_CLIENT))
@@ -167,7 +167,7 @@ class TaggingServiceTest {
         every { SdkFhirElementFactory.resolveFhirVersion(Patient::class.java) } returns FhirContract.FhirVersion.FHIR_3
         // When
         @Suppress("UNCHECKED_CAST")
-        val result = taggingService.getTagFromType(type::class.java as Class<Any>)
+        val result = taggingService.getTagsFromType(type::class.java as Class<Any>)
 
         // Then
         assertEquals(2, result.size)
@@ -218,7 +218,7 @@ class TaggingServiceTest {
         every { SdkFhirElementFactory.resolveFhirVersion(R4Patient::class.java) } returns FhirContract.FhirVersion.FHIR_4
         // When
         @Suppress("UNCHECKED_CAST")
-        val result = taggingService.getTagFromType(type::class.java as Class<Any>)
+        val result = taggingService.getTagsFromType(type::class.java as Class<Any>)
 
         // Then
         assertEquals(2, result.size)
@@ -261,12 +261,48 @@ class TaggingServiceTest {
     @Test
     fun `Given, getTagFromType is called with null, it returns a Map, which contains TAG_APPDATA_KEY`() {//getTagFromType_shouldReturnEmptyList_whenResourceTypeNull
         // When
-        val result = taggingService.getTagFromType(null)
+        val result = taggingService.getTagsFromType(null)
 
         // Then
-        assertEquals(1, result.size.toLong())
+        assertEquals(1, result.size)
         assertTrue(result.containsKey(TAG_APPDATA_KEY))
         assertEquals(TAG_APPDATA_VALUE, result[TAG_APPDATA_KEY])
+    }
+
+    @Test
+    fun `Given, tagVersion is called with FHIR_3 and a map, it adds the appropriate TAG_FHIR_VERSION field`() {
+        // Given
+        val map = hashMapOf<String, String>()
+
+        // When
+        taggingService.tagVersion(map, FhirContract.FhirVersion.FHIR_3)
+
+        assertTrue(map.containsKey(TAG_FHIR_VERSION))
+        assertEquals(FhirContract.FhirVersion.FHIR_3.version, map[TAG_FHIR_VERSION])
+    }
+
+    @Test
+    fun `Given, tagVersion is called with FHIR_4 and a map, it adds the appropriate TAG_FHIR_VERSION field`() {
+        // Given
+        val map = hashMapOf<String, String>()
+
+        // When
+        taggingService.tagVersion(map, FhirContract.FhirVersion.FHIR_4)
+
+        assertTrue(map.containsKey(TAG_FHIR_VERSION))
+        assertEquals(FhirContract.FhirVersion.FHIR_4.version, map[TAG_FHIR_VERSION])
+    }
+
+    @Test
+    fun `Given, tagVersion is called with UNKNOWN and a map, it adds the appropriate TAG_FHIR_VERSION field`() {
+        // Given
+        val map = hashMapOf<String, String>()
+
+        // When
+        taggingService.tagVersion(map, FhirContract.FhirVersion.UNKNOWN)
+
+        assertTrue(map.containsKey(TAG_APPDATA_KEY))
+        assertEquals(TAG_APPDATA_VALUE, map[TAG_APPDATA_KEY])
     }
 
     companion object {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the count functionality for Fhir4Records.
Additionally it fixes an issue encountered at countRecords while counting all Fhir3Records.

## Motivation and Context
Currently DataDonation is need of the count functionality for Fhir4.
This PR depends on #59.

## How is it being implemented?
This PR makes 4 major steps:
1. It adds a new function to the TaggingService(`tagVersion`) to enable version tagging via FhirVersion,
2. It refactors and fixes `countRecords` in the RecordService
3. It adds the Fhir4 functionality for count to the RecordService
4. It adds the Fhir4 functionality for count to the Fhir4Client.
5. It takes advantage of the behaviour which results from `DomainRefence` while tagging a query against the Backend.

## How Has This Been Tested?
All new methods have been covered by unittests. Additionally the exiting functional tests for count have been extended to also cover Fhir4.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
