### PR TITLE
[NAT-548] Fix NullPointerException for DomainResource

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,7 @@ toc::[]
 
 * RecordService#deleteRecord invocation had mixed user and resource id.
 * RecordService#fetchRecords invocation had mixed user and resource id.
+* NullPointerException when using DomainResource as resourceType for fetch/search.
 
 === Bumped
 

--- a/sample-android/src/main/java/care/data4life/sample/DocumentsActivity.java
+++ b/sample-android/src/main/java/care/data4life/sample/DocumentsActivity.java
@@ -51,6 +51,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import care.data4life.fhir.stu3.model.Attachment;
 import care.data4life.fhir.stu3.model.DocumentReference;
+import care.data4life.fhir.stu3.model.DomainResource;
 import care.data4life.sdk.Data4LifeClient;
 import care.data4life.sdk.call.DataRecord;
 import care.data4life.sdk.call.Task;
@@ -67,7 +68,7 @@ public class DocumentsActivity extends AppCompatActivity {
     private static final String TAG = DocumentsActivity.class.getSimpleName();
 
     private static final int INTENT_FILE_PICKER = 434;
-    public List<Record<DocumentReference>> records = new ArrayList<>();
+    public List<Record<DomainResource>> records = new ArrayList<>();
     private Data4LifeClient client;
     private CRUDBenchmark benchmark;
     private FloatingActionButton mAddFAB;
@@ -266,9 +267,15 @@ public class DocumentsActivity extends AppCompatActivity {
     private void fetchDocuments(int offset) {
         mDocumentsSRL.setRefreshing(true);
 
-        fetchTask = client.fetchRecords(DocumentReference.class, fromDate, toDate, 20, offset, new ResultListener<List<Record<DocumentReference>>>() {
+        fetchTask = client.fetchRecords(
+                DomainResource.class,
+                fromDate,
+                toDate,
+                20,
+                offset,
+                new ResultListener<List<Record<DomainResource>>>() {
             @Override
-            public void onSuccess(List<Record<DocumentReference>> records) {
+            public void onSuccess(List<Record<DomainResource>> records) {
                 runOnUiThread(() -> {
                     DocumentsActivity.this.records.addAll(records);
                     if (records.size() == 0) {
@@ -295,9 +302,16 @@ public class DocumentsActivity extends AppCompatActivity {
             this.documents = documents;
         }
 
-        void bindDocuments(List<Record<DocumentReference>> documents) {
+        void bindDocuments(List<Record<DomainResource>> documents) {
+            List<Record<DocumentReference>> docRefs = new ArrayList<>();
+            for (Record record : documents) {
+                if (record.getResource() instanceof DocumentReference) {
+                    docRefs.add(record);
+                }
+            }
+
             this.documents.clear();
-            this.documents.addAll(documents);
+            this.documents.addAll(docRefs);
             notifyDataSetChanged();
         }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingService.kt
@@ -85,12 +85,17 @@ class TaggingService(
     override fun getTagFromType(
             resourceType: Class<Any>?
     ): HashMap<String, String> {
-        return hashMapOf<String, String>().also {
+        return hashMapOf<String, String>().also { tags ->
             if (resourceType == null) {
-                it[TAG_APPDATA_KEY] = TAG_APPDATA_VALUE
+                tags[TAG_APPDATA_KEY] = TAG_APPDATA_VALUE
             } else {
-                it[TAG_RESOURCE_TYPE] = fhirElementFactory.getFhirTypeForClass(resourceType)!!
-                it[TAG_FHIR_VERSION] = fhirElementFactory.resolveFhirVersion(resourceType).version
+                fhirElementFactory.getFhirTypeForClass(resourceType).also { resourceTagValue ->
+                    if(resourceTagValue is String) {
+                        tags[TAG_RESOURCE_TYPE] = resourceTagValue
+                    }
+                }
+
+                tags[TAG_FHIR_VERSION] = fhirElementFactory.resolveFhirVersion(resourceType).version
             }
         }
     }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchIntegration.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchIntegration.kt
@@ -843,6 +843,77 @@ class RecordServiceFetchIntegration : RecordServiceIntegrationBase() {
     }
 
     @Test
+    fun `Given, fetchFhir3Records is called, with its appropriate payloads and a DomainResource as resourceType, it returns a List of Records`() {
+        // Given
+        val tags = mapOf(
+            "partner" to "partner=$PARTNER_ID".toLowerCase(),
+            "client" to "client=${
+                URLEncoder.encode(CLIENT_ID.toLowerCase(), StandardCharsets.UTF_8.displayName())
+            }",
+            "fhirversion" to "fhirversion=${
+                "3.0.1".replace(".", "%2e")
+            }",
+            "resourcetype" to "resourcetype=documentreference"
+        )
+
+        val encodedEncyrptedResourceType = "cmVzb3VyY2V0eXBlPWRvY3VtZW50cmVmZXJlbmNl"
+        val encodedEncryptedVersion = "ZmhpcnZlcnNpb249MyUyZTAlMmUx"
+
+        encryptedBody = "ZW5jcnlwdGVk"
+        encryptedBody2 = "Wlc1amNubHdkR1Zr"
+
+        encryptedRecord = EncryptedRecord(
+            commonKeyId,
+            RECORD_ID,
+            listOf("cGFydG5lcj1iNDY=", "Y2xpZW50PWI0NiUyM3Rlc3Q=", encodedEncryptedVersion, encodedEncyrptedResourceType),
+            encryptedBody,
+            CREATION_DATE,
+            encryptedDataKey,
+            encryptedAttachmentKey,
+            ModelVersion.CURRENT,
+            UPDATE_DATE
+        )
+
+        encryptedRecord2 = EncryptedRecord(
+            commonKeyId,
+            RECORD_ID,
+            listOf("cGFydG5lcj1iNDY=", "Y2xpZW50PWI0NiUyM3Rlc3Q=", encodedEncryptedVersion, encodedEncyrptedResourceType),
+            encryptedBody2,
+            CREATION_DATE,
+            encryptedDataKey,
+            encryptedAttachmentKey,
+            ModelVersion.CURRENT,
+            UPDATE_DATE
+        )
+
+        stringifiedResource = "{\"content\":[{\"attachment\":{\"hash\":\"jwZ0G6YALQ4N8RGNHzJHIgX6j+I=\",\"id\":\"42\",\"size\":42}}],\"identifier\":[{\"assigner\":{\"reference\":\"partnerId\"},\"value\":\"d4l_f_p_t#42\"}],\"resourceType\":\"DocumentReference\"}"
+        stringifiedResource2 = "{\"content\":[{\"attachment\":{\"hash\":\"jwZ0G6YALQ4N8RGNHzJHIgX6j+I=\",\"id\":\"attachmentId#previewId#thumbnailId\",\"size\":42}}],\"resourceType\":\"DocumentReference\"}"
+
+        runFhirFlowBatch(
+            tags,
+            encryptedTags = listOf(encodedEncryptedVersion)
+        )
+
+        // When
+        val result = recordService.fetchFhir3Records(
+            USER_ID,
+            Fhir3Resource::class.java,
+            listOf(),
+            null,
+            null,
+            42,
+            23
+        ).blockingGet()
+
+        // Then
+        Truth.assertThat(result).hasSize(2)
+        Truth.assertThat(result[0].resource).isInstanceOf(Fhir3Resource::class.java)
+        Truth.assertThat(result[1].resource).isInstanceOf(Fhir3Resource::class.java)
+        Truth.assertThat(result[0].annotations).isEmpty()
+        Truth.assertThat(result[1].annotations).isEmpty()
+    }
+
+    @Test
     fun `Given, fetchFhir4Records is called, with its appropriate payloads, it returns a List of Fhir4Records`() {
         // Given
         val tags = mapOf(
@@ -1011,6 +1082,77 @@ class RecordServiceFetchIntegration : RecordServiceIntegrationBase() {
         Truth.assertThat(result).hasSize(1)
         Truth.assertThat(result[0].resource).isInstanceOf(Fhir4Resource::class.java)
         Truth.assertThat(result[0].annotations).isEqualTo(listOf("wow", "it", "works"))
+    }
+
+    @Test
+    fun `Given, fetchFhir4Records is called, with its appropriate payloads and a DomainResource as resourceType, it returns a List of Records`() {
+        // Given
+        val tags = mapOf(
+            "partner" to "partner=$PARTNER_ID".toLowerCase(),
+            "client" to "client=${
+                URLEncoder.encode(CLIENT_ID.toLowerCase(), StandardCharsets.UTF_8.displayName())
+            }",
+            "fhirversion" to "fhirversion=${
+                "4.0.1".replace(".", "%2e")
+            }",
+            "resourcetype" to "resourcetype=documentreference"
+        )
+
+        val encodedEncyrptedResourceType = "cmVzb3VyY2V0eXBlPWRvY3VtZW50cmVmZXJlbmNl"
+        val encodedEncryptedVersion = "ZmhpcnZlcnNpb249NCUyZTAlMmUx"
+
+        encryptedBody = "ZW5jcnlwdGVk"
+        encryptedBody2 = "Wlc1amNubHdkR1Zr"
+
+        encryptedRecord = EncryptedRecord(
+            commonKeyId,
+            RECORD_ID,
+            listOf("cGFydG5lcj1iNDY=", "Y2xpZW50PWI0NiUyM3Rlc3Q=", encodedEncryptedVersion, encodedEncyrptedResourceType),
+            encryptedBody,
+            CREATION_DATE,
+            encryptedDataKey,
+            encryptedAttachmentKey,
+            ModelVersion.CURRENT,
+            UPDATE_DATE
+        )
+
+        encryptedRecord2 = EncryptedRecord(
+            commonKeyId,
+            RECORD_ID,
+            listOf("cGFydG5lcj1iNDY=", "Y2xpZW50PWI0NiUyM3Rlc3Q=", encodedEncryptedVersion, encodedEncyrptedResourceType),
+            encryptedBody2,
+            CREATION_DATE,
+            encryptedDataKey,
+            encryptedAttachmentKey,
+            ModelVersion.CURRENT,
+            UPDATE_DATE
+        )
+
+        stringifiedResource = "{\"content\":[{\"attachment\":{\"hash\":\"jwZ0G6YALQ4N8RGNHzJHIgX6j+I=\",\"id\":\"42\",\"size\":42}}],\"identifier\":[{\"assigner\":{\"reference\":\"partnerId\"},\"value\":\"d4l_f_p_t#42\"}],\"resourceType\":\"DocumentReference\"}"
+        stringifiedResource2 = "{\"content\":[{\"attachment\":{\"hash\":\"jwZ0G6YALQ4N8RGNHzJHIgX6j+I=\",\"id\":\"attachmentId#previewId#thumbnailId\",\"size\":42}}],\"resourceType\":\"DocumentReference\"}"
+
+        runFhirFlowBatch(
+            tags,
+            encryptedTags = listOf(encodedEncryptedVersion)
+        )
+
+        // When
+        val result = recordService.fetchFhir4Records(
+            USER_ID,
+            Fhir4Resource::class.java,
+            listOf(),
+            null,
+            null,
+            42,
+            23
+        ).blockingGet()
+
+        // Then
+        Truth.assertThat(result).hasSize(2)
+        Truth.assertThat(result[0].resource).isInstanceOf(Fhir4Resource::class.java)
+        Truth.assertThat(result[1].resource).isInstanceOf(Fhir4Resource::class.java)
+        Truth.assertThat(result[0].annotations).isEmpty()
+        Truth.assertThat(result[1].annotations).isEmpty()
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TaggingServiceTest.kt
@@ -183,6 +183,31 @@ class TaggingServiceTest {
     }
 
     @Test
+    fun `Given, getTagFromType is called with a Class of a Fhir3Resource, it does not set the TAG_RESOURCE_TYPE but the TAG_FHIR_VERSION, if the resource was not determined`() {
+        // Given
+        val type: Fhir3Resource = mockk()
+        val resourceType = null
+
+        mockkObject(SdkFhirElementFactory)
+        every { SdkFhirElementFactory.getFhirTypeForClass(Fhir3Resource::class.java) } returns resourceType
+        every { SdkFhirElementFactory.resolveFhirVersion(Fhir3Resource::class.java) } returns FhirContract.FhirVersion.FHIR_3
+        // When
+        @Suppress("UNCHECKED_CAST")
+        val result = taggingService.getTagFromType(type::class.java as Class<Any>)
+
+        // Then
+        assertEquals(1, result.size)
+        assertFalse(result.containsKey(TAG_RESOURCE_TYPE))
+        assertTrue(result.containsKey(TAG_FHIR_VERSION))
+        assertEquals(FhirContract.FhirVersion.FHIR_3.version, result[TAG_FHIR_VERSION])
+
+        verify(exactly = 1) { SdkFhirElementFactory.getFhirTypeForClass(Fhir3Resource::class.java) }
+        verify(exactly = 1) { SdkFhirElementFactory.resolveFhirVersion(Fhir3Resource::class.java) }
+
+        unmockkObject(SdkFhirElementFactory)
+    }
+
+    @Test
     fun `Given, getTagFromType is called with a Class of a Fhir4Resource, it returns a Map, which contains TAG_RESOURCE_TYPE and TAG_FHIR_VERSION for the given type`() {
         // Given
         val type: R4Patient = mockk()
@@ -204,6 +229,31 @@ class TaggingServiceTest {
 
         verify(exactly = 1) { SdkFhirElementFactory.getFhirTypeForClass(R4Patient::class.java) }
         verify(exactly = 1) { SdkFhirElementFactory.resolveFhirVersion(R4Patient::class.java) }
+
+        unmockkObject(SdkFhirElementFactory)
+    }
+
+    @Test
+    fun `Given, getTagFromType is called with a Class of a Fhir4Resource, it does not set the TAG_RESOURCE_TYPE but the TAG_FHIR_VERSION, if the resource was not determined`() {
+        // Given
+        val type: Fhir4Resource = mockk()
+        val resourceType = null
+
+        mockkObject(SdkFhirElementFactory)
+        every { SdkFhirElementFactory.getFhirTypeForClass(Fhir4Resource::class.java) } returns resourceType
+        every { SdkFhirElementFactory.resolveFhirVersion(Fhir4Resource::class.java) } returns FhirContract.FhirVersion.FHIR_4
+        // When
+        @Suppress("UNCHECKED_CAST")
+        val result = taggingService.getTagFromType(type::class.java as Class<Any>)
+
+        // Then
+        assertEquals(1, result.size)
+        assertFalse(result.containsKey(TAG_RESOURCE_TYPE))
+        assertTrue(result.containsKey(TAG_FHIR_VERSION))
+        assertEquals(FhirContract.FhirVersion.FHIR_4.version, result[TAG_FHIR_VERSION])
+
+        verify(exactly = 1) { SdkFhirElementFactory.getFhirTypeForClass(Fhir4Resource::class.java) }
+        verify(exactly = 1) { SdkFhirElementFactory.resolveFhirVersion(Fhir4Resource::class.java) }
 
         unmockkObject(SdkFhirElementFactory)
     }

--- a/sdk-core/src/test/java/care/data4life/sdk/wrapper/FhirElementFactoryTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/wrapper/FhirElementFactoryTest.kt
@@ -39,7 +39,7 @@ class FhirElementFactoryTest {
     }
 
     @Test
-    fun `Given, getFhirTypeForClass is called with a valid Fhir3Resource Class, it returns its name`() {
+    fun `Given, getFhirTypeForClass is called with a subtype of Fhir3Resource Class, it returns its name`() {
         // Given
         val resource = buildDocumentReferenceFhir3()
 


### PR DESCRIPTION
…omType

<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes the current occurrence of a Nullpointer Exception while calling `fetchRecords` with a `DomainResource`.

## Motivation and Context
When calling `fetch/search` and using a `DomainResource` the SDK fails with a NullPointerException, which relates to the transition from Java to Kotlin.
Also allowed the former behaviour to use the translation from `DomainResource` to `null` in SDK to query all related Records.

## How is it being implemented?
This simply changes the mandatory String in the TaggingService#getTagFromType to optional and only tags the type if a resourceType is present.

## How Has This Been Tested?
2 new unit tests had been added for the TaggingService for Fhir3 and Fhir4. 
Also 2 new integration tests are in place to proof DomainResource is now working on `fetchRecords` for Fhir3 and Fhir4.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
