### PR TITLE
Fix date formatting on fetch/search

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@ toc::[]
 * RecordService#deleteRecord invocation had mixed user and resource id.
 * RecordService#fetchRecords invocation had mixed user and resource id.
 * NullPointerException when using DomainResource as resourceType for fetch/search.
+* RecordService called on fetch/search DATE_FORMAT instead DATE_FORMATTER.
 
 === Bumped
 

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -1188,12 +1188,12 @@ class RecordService(
         const val PREVIEW_ID_POS = 2
         const val THUMBNAIL_ID_POS = 3
         // TODO refactor
-        private val DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT, Locale.US)
+        internal val DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT, Locale.US)
         private val DATE_TIME_FORMATTER = DateTimeFormatterBuilder()
                 .parseLenient()
                 .appendPattern(DATE_TIME_FORMAT)
                 .toFormatter(Locale.US)
         private val UTC_ZONE_ID = ZoneId.of("UTC")
-        internal fun formatDate(dateTime: LocalDate): String = DATE_FORMAT.format(dateTime)
+        internal fun formatDate(dateTime: LocalDate): String = DATE_FORMATTER.format(dateTime)
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchIntegration.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchIntegration.kt
@@ -1431,6 +1431,7 @@ class RecordServiceFetchIntegration : RecordServiceIntegrationBase() {
         }
     }
 
-    // ToDo: Case any Fhir<->Data
-    // ToDo: Cases for fetch**Records
+    // TODO: Case any Fhir<->Data
+    // TODO: Cases for fetch**Records
+    // TODO: Add test cases for search with start and end dates
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
@@ -416,8 +416,8 @@ class RecordServiceFetchRecordsTest {
         mockkObject(RecordMapper)
         mockkObject(RecordService)
 
-        every { RecordService.formatDate(startDate) } returns start
-        every { RecordService.formatDate(endDate) } returns end
+        every { RecordService.DATE_FORMATTER.format(startDate) } returns start
+        every { RecordService.DATE_FORMATTER.format(endDate) } returns end
         every { taggingService.getTagFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation
@@ -893,8 +893,8 @@ class RecordServiceFetchRecordsTest {
         mockkObject(RecordMapper)
         mockkObject(RecordService)
 
-        every { RecordService.formatDate(startDate) } returns start
-        every { RecordService.formatDate(endDate) } returns end
+        every { RecordService.DATE_FORMATTER.format(startDate) } returns start
+        every { RecordService.DATE_FORMATTER.format(endDate) } returns end
         every { taggingService.getTagFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
         every { tagEncryptionService.encryptTags(tags) } returns encryptedTags
         every { tagEncryptionService.encryptAnnotations(defaultAnnotation) } returns defaultAnnotation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes the date formatting on `fetchRecords`(aka `searchRecords`)

## Motivation and Context
Currently the date formatting is broken `fetchRecords`(aka `searchRecords`) due to some recent changes.

## How is it being implemented?
By changing `formatDate` in the Companion of the RecordService to make use of `DATE_FORMATTER` instead of `DATE_FORMAT`.

## How Has This Been Tested?
The recently introduced unit test had been modified to refer to the underlying call for now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
