### PR TITLE
[SDK-565] Add FHIR4 support for download Record in the RecordService

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,8 +16,8 @@ toc::[]
 
 === Added
 
-* Version control for supported/unsupported versions
-* The Client now exposes the UserId
+* Version control for supported/unsupported versions.
+* The Client now exposes the UserId.
 
 === Changed
 

--- a/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
+++ b/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
@@ -201,7 +201,7 @@ public class LegacyDataClient implements SdkContract.LegacyDataClient {
     @Override
     public <T extends DomainResource> Task downloadRecord(String recordId, ResultListener<Record<T>> listener) {
         Single<Record<T>> operation = userService.getUserID()
-                .flatMap(uid -> recordService.downloadRecord(recordId, uid));
+                .flatMap(uid -> recordService.downloadFhir3Record(recordId, uid));
         return handler.executeSingle(operation, listener);
     }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
+++ b/sdk-core/src/main/java/care/data4life/sdk/LegacyDataClient.java
@@ -215,14 +215,14 @@ public class LegacyDataClient implements SdkContract.LegacyDataClient {
     @Override
     public Task downloadAttachment(String recordId, String attachmentId, DownloadType type, ResultListener<Attachment> listener) {
         Single<Attachment> operation = userService.getUserID()
-                .flatMap(uid -> recordService.downloadAttachment(recordId, attachmentId, uid, type));
+                .flatMap(uid -> recordService.downloadFhir3Attachment(recordId, attachmentId, uid, type));
         return handler.executeSingle(operation, listener);
     }
 
     @Override
     public Task downloadAttachments(String recordId, List<String> attachmentIds, DownloadType type, ResultListener<List<Attachment>> listener) {
         Single<List<Attachment>> operation = userService.getUserID()
-                .flatMap(uid -> recordService.downloadAttachments(recordId, attachmentIds, uid, type));
+                .flatMap(uid -> recordService.downloadFhir3Attachments(recordId, attachmentIds, uid, type));
         return handler.executeSingle(operation, listener);
     }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -28,6 +28,7 @@ import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.data.DataResource
 import care.data4life.sdk.fhir.Fhir3Attachment
 import care.data4life.sdk.fhir.Fhir3Resource
+import care.data4life.sdk.fhir.Fhir4Attachment
 import care.data4life.sdk.fhir.Fhir4Resource
 import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.CoreRuntimeException
@@ -688,33 +689,77 @@ class RecordService internal constructor(
         ) as DecryptedBaseRecord<T>
     }
 
-    override fun downloadAttachment(
+    override fun downloadFhir3Attachment(
         recordId: String,
         attachmentId: String,
         userId: String,
         type: DownloadType
-    ): Single<Fhir3Attachment> = downloadAttachments(
+    ): Single<Fhir3Attachment> = downloadFhir3Attachments(
         recordId,
         listOf(attachmentId),
         userId,
         type
     ).map { it[0] }
 
-    override fun downloadAttachments(
+    override fun downloadFhir4Attachment(
+        recordId: String,
+        attachmentId: String,
+        userId: String,
+        type: DownloadType
+    ): Single<Fhir4Attachment> = downloadFhir4Attachments(
+        recordId,
+        listOf(attachmentId),
+        userId,
+        type
+    ).map { it[0] }
+
+    @Throws(IllegalArgumentException::class)
+    override fun downloadFhir3Attachments(
         recordId: String,
         attachmentIds: List<String>,
         userId: String,
         type: DownloadType
-    ): Single<List<Fhir3Attachment>> = apiService
+    ): Single<List<Fhir3Attachment>> = downloadAttachments<Fhir3Resource, Fhir3Attachment>(
+        recordId,
+        attachmentIds,
+        userId,
+        type
+    ) { resource -> resource is Fhir3Resource }
+
+    @Throws(IllegalArgumentException::class)
+    override fun downloadFhir4Attachments(
+        recordId: String,
+        attachmentIds: List<String>,
+        userId: String,
+        type: DownloadType
+    ): Single<List<Fhir4Attachment>> = downloadAttachments<Fhir4Resource, Fhir4Attachment>(
+        recordId,
+        attachmentIds,
+        userId,
+        type
+    ) { resource -> resource is Fhir4Resource }
+
+    @Throws(IllegalArgumentException::class)
+    private fun <T : Any, R : Any> downloadAttachments(
+        recordId: String,
+        attachmentIds: List<String>,
+        userId: String,
+        type: DownloadType,
+        resourceBarrier: (resource: Any) -> Boolean
+    ): Single<List<R>> = apiService
         .fetchRecord(alias, userId, recordId)
-        .map { decryptRecord<Fhir3Resource>(it, userId) }
-        .flatMap {
-            downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
-                attachmentIds,
-                userId,
-                type,
-                it as DecryptedFhir3Record<Fhir3Resource>
-            )
+        .map { decryptRecord<T>(it, userId) }
+        .flatMap { record ->
+            if (resourceBarrier(record.resource)) {
+                downloadAttachmentsFromStorage<T, R>(
+                    attachmentIds,
+                    userId,
+                    type,
+                    record
+                )
+            } else {
+                throw IllegalArgumentException("The given Record does not match the expected resource type.")
+            }
         }
 
     @Throws(

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -745,9 +745,9 @@ class RecordService internal constructor(
                 throw DataValidationException.IdUsageViolation("Please provide correct attachment ids!")
 
             setAttachmentIdForDownloadType(
-                validRawAttachments,
-                fhirAttachmentHelper.getIdentifier(resource) as List<Fhir3Identifier>?,
-                type
+                    validAttachments,
+                    fhirAttachmentHelper.getIdentifier(resource),
+                    type
             )
 
             return attachmentService.download(
@@ -1094,12 +1094,17 @@ class RecordService internal constructor(
     // TODO move to AttachmentService -> Thumbnail handling
     @Throws(DataValidationException.IdUsageViolation::class)
     fun setAttachmentIdForDownloadType(
+<<<<<<< HEAD
         attachments: List<Any>,
         identifiers: List<Any>?,
         type: DownloadType
+=======
+            attachments: List<WrapperContract.Attachment>,
+            identifiers: List<Any>?,
+            type: DownloadType
+>>>>>>> 50700b9... Use AttachmentWrapper in setAttachmentId
     ) {
-        for (rawAttachment in attachments) {
-            val attachment = attachmentFactory.wrap(rawAttachment)
+        for (attachment in attachments) {
             val additionalIds = extractAdditionalAttachmentIds(
                 identifiers,
                 attachment.id

--- a/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
@@ -56,7 +56,8 @@ interface RecordContract {
 
         fun countAllFhir3Records(userId: String, annotations: List<String>): Single<Int>
 
-        fun <T : Fhir3Resource> downloadRecord(recordId: String, userId: String): Single<Record<T>>
+        fun <T : Fhir3Resource> downloadFhir3Record(recordId: String, userId: String): Single<Record<T>>
+        fun <T : Fhir4Resource> downloadFhir4Record(recordId: String, userId: String): Single<Fhir4Record<T>>
 
         @Throws(IllegalArgumentException::class)
         fun downloadFhir3Attachment(

--- a/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
@@ -21,6 +21,7 @@ import care.data4life.sdk.call.Fhir4Record
 import care.data4life.sdk.data.DataResource
 import care.data4life.sdk.fhir.Fhir3Attachment
 import care.data4life.sdk.fhir.Fhir3Resource
+import care.data4life.sdk.fhir.Fhir4Attachment
 import care.data4life.sdk.fhir.Fhir4Resource
 import care.data4life.sdk.model.DownloadType
 import care.data4life.sdk.model.Record
@@ -57,19 +58,37 @@ interface RecordContract {
 
         fun <T : Fhir3Resource> downloadRecord(recordId: String, userId: String): Single<Record<T>>
 
-        fun downloadAttachment(
+        @Throws(IllegalArgumentException::class)
+        fun downloadFhir3Attachment(
             recordId: String,
             attachmentId: String,
             userId: String,
             type: DownloadType
         ): Single<Fhir3Attachment>
 
-        fun downloadAttachments(
+        @Throws(IllegalArgumentException::class)
+        fun downloadFhir3Attachments(
             recordId: String,
             attachmentIds: List<String>,
             userId: String,
             type: DownloadType
         ): Single<List<Fhir3Attachment>>
+
+        @Throws(IllegalArgumentException::class)
+        fun downloadFhir4Attachment(
+            recordId: String,
+            attachmentId: String,
+            userId: String,
+            type: DownloadType
+        ): Single<Fhir4Attachment>
+
+        @Throws(IllegalArgumentException::class)
+        fun downloadFhir4Attachments(
+            recordId: String,
+            attachmentIds: List<String>,
+            userId: String,
+            type: DownloadType
+        ): Single<List<Fhir4Attachment>>
 
         companion object {
             const val EMPTY_RECORD_ID = ""

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAdditionalResourceTypeModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAdditionalResourceTypeModuleTest.kt
@@ -15,9 +15,22 @@
  */
 package care.data4life.sdk
 
-
 import care.data4life.crypto.GCKey
 import care.data4life.fhir.r4.model.Extension
+import care.data4life.sdk.attachment.AttachmentContract
+import care.data4life.sdk.config.DataRestrictionException
+import care.data4life.sdk.crypto.CryptoContract
+import care.data4life.sdk.fhir.Fhir3Attachment
+import care.data4life.sdk.fhir.Fhir3Resource
+import care.data4life.sdk.fhir.Fhir4Attachment
+import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
+import care.data4life.sdk.model.DownloadType
+import care.data4life.sdk.network.model.DecryptedR4Record
+import care.data4life.sdk.network.model.DecryptedRecord
+import care.data4life.sdk.network.model.EncryptedRecord
+import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
+import care.data4life.sdk.tag.TaggingContract
 import care.data4life.sdk.test.util.GenericTestDataProvider.ADDITIONAL_ID
 import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
 import care.data4life.sdk.test.util.GenericTestDataProvider.ASSIGNER
@@ -34,20 +47,6 @@ import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID
 import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.test.util.GenericTestDataProvider.VALUE_ID
 import care.data4life.sdk.test.util.GenericTestDataProvider.VALUE_INDICATOR
-import care.data4life.sdk.attachment.AttachmentContract
-import care.data4life.sdk.config.DataRestrictionException
-import care.data4life.sdk.crypto.CryptoContract
-import care.data4life.sdk.fhir.Fhir3Attachment
-import care.data4life.sdk.fhir.Fhir3Resource
-import care.data4life.sdk.fhir.Fhir4Attachment
-import care.data4life.sdk.fhir.Fhir4Resource
-import care.data4life.sdk.fhir.FhirContract
-import care.data4life.sdk.model.DownloadType
-import care.data4life.sdk.network.model.DecryptedR4Record
-import care.data4life.sdk.network.model.DecryptedRecord
-import care.data4life.sdk.network.model.EncryptedRecord
-import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
-import care.data4life.sdk.tag.TaggingContract
 import care.data4life.sdk.test.util.TestAttachmentHelper
 import care.data4life.sdk.test.util.TestResourceHelper
 import care.data4life.sdk.util.Base64
@@ -60,7 +59,6 @@ import io.mockk.spyk
 import io.reactivex.Single
 import org.junit.Assume
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -82,7 +80,6 @@ import care.data4life.fhir.stu3.model.Questionnaire as Fhir3Questionnaire
 import care.data4life.fhir.stu3.model.QuestionnaireResponse as Fhir3QuestionnaireResponse
 import care.data4life.fhir.stu3.util.FhirAttachmentHelper as Fhir3AttachmentHelper
 
-
 @RunWith(Parameterized::class)
 class RecordServiceAdditionalResourceTypeModuleTest {
     private lateinit var recordService: RecordService
@@ -102,17 +99,17 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         clearAllMocks()
 
         recordService = spyk(
-                RecordService(
-                        PARTNER_ID,
-                        ALIAS,
-                        apiService,
-                        tagEncryptionService,
-                        taggingService,
-                        fhirService,
-                        attachmentService,
-                        cryptoService,
-                        errorHandler
-                )
+            RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler
+            )
         )
     }
 
@@ -120,42 +117,42 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         @JvmStatic
         @Parameterized.Parameters(name = "applied on {1}")
         fun parameter() = listOf(
-                arrayOf(
-                        "Patient",
-                        "patient",
-                        listOf("common"),
-                        "1"
-                ),
-                arrayOf(
-                        "QuestionnaireResponse",
-                        "questionnaireResponse",
-                        listOf("common"),
-                        "1"
-                ),
-                arrayOf(
-                        "Medication",
-                        "medication",
-                        listOf("fhir3"),
-                        "1"
-                ),
-                arrayOf(
-                        "Observation",
-                        "observation",
-                        listOf("fhir3"),
-                        "1"
-                ),
-                arrayOf(
-                        "Observation",
-                        "observation-with-component",
-                        listOf("fhir3"),
-                        "2"
-                ),
-                arrayOf(
-                        "Questionnaire",
-                        "questionnaire",
-                        listOf("fhir3", "fhir4"),
-                        "1"
-                )
+            arrayOf(
+                "Patient",
+                "patient",
+                listOf("common"),
+                "1"
+            ),
+            arrayOf(
+                "QuestionnaireResponse",
+                "questionnaireResponse",
+                listOf("common"),
+                "1"
+            ),
+            arrayOf(
+                "Medication",
+                "medication",
+                listOf("fhir3"),
+                "1"
+            ),
+            arrayOf(
+                "Observation",
+                "observation",
+                listOf("fhir3"),
+                "1"
+            ),
+            arrayOf(
+                "Observation",
+                "observation-with-component",
+                listOf("fhir3"),
+                "2"
+            ),
+            arrayOf(
+                "Questionnaire",
+                "questionnaire",
+                listOf("fhir3", "fhir4"),
+                "1"
+            )
         )
     }
 
@@ -172,7 +169,7 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     lateinit var expectedSize: String
 
     private fun determineFhir3Folder(
-            resourcePrefixes: List<String>
+        resourcePrefixes: List<String>
     ): String {
         return if (resourcePrefixes.contains("common")) {
             "common"
@@ -182,7 +179,7 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     }
 
     private fun determineFhir4Folder(
-            resourcePrefixes: List<String>
+        resourcePrefixes: List<String>
     ): String {
         return if (resourcePrefixes.contains("common")) {
             "common"
@@ -221,8 +218,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     }
 
     private fun setFhir3Id(
-            resource: Fhir3Resource,
-            identifiers: List<Fhir3Identifier>
+        resource: Fhir3Resource,
+        identifiers: List<Fhir3Identifier>
     ) {
         when (resource) {
             is Fhir3Medication -> return
@@ -235,8 +232,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     }
 
     private fun setFhir4Id(
-            resource: Fhir4Resource,
-            identifiers: List<Fhir4Identifier>
+        resource: Fhir4Resource,
+        identifiers: List<Fhir4Identifier>
     ) {
         when (resource) {
             is Fhir4Observation -> resource.identifier = identifiers
@@ -252,8 +249,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
             is Fhir3Medication -> resource.image = attachments
             is Fhir3Observation -> {
                 resource.component = mutableListOf(
-                        Fhir3Observation.ObservationComponent(null),
-                        Fhir3Observation.ObservationComponent(null)
+                    Fhir3Observation.ObservationComponent(null),
+                    Fhir3Observation.ObservationComponent(null)
                 )
                 resource.component!![0].valueAttachment = attachments[0]
                 resource.component!![1].valueAttachment = attachments[1]
@@ -261,8 +258,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
             is Fhir3Patient -> resource.photo = attachments
             is Fhir3Questionnaire -> {
                 resource.item = mutableListOf(
-                        Fhir3Questionnaire.QuestionnaireItem("", null),
-                        Fhir3Questionnaire.QuestionnaireItem("", null)
+                    Fhir3Questionnaire.QuestionnaireItem("", null),
+                    Fhir3Questionnaire.QuestionnaireItem("", null)
                 )
                 resource.item!![0].initialAttachment = attachments[0]
                 resource.item!![1].initialAttachment = attachments[1]
@@ -280,10 +277,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         return when (resource) {
             is Fhir4Observation -> {
                 resource.component!![0].extension = mutableListOf(
-                        Extension("a"),
-                        Extension("b")
+                    Extension("a"),
+                    Extension("b")
                 )
-
 
                 resource.component!![0].extension!![0].valueAttachment = attachments[0]
                 resource.component!![0].extension!![1].valueAttachment = attachments[1]
@@ -291,8 +287,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
             is Fhir4Patient -> resource.photo = attachments
             is Fhir4Questionnaire -> {
                 resource.item = mutableListOf(
-                        Fhir4Questionnaire.QuestionnaireItem("", null),
-                        Fhir4Questionnaire.QuestionnaireItem("", null)
+                    Fhir4Questionnaire.QuestionnaireItem("", null),
+                    Fhir4Questionnaire.QuestionnaireItem("", null)
                 )
                 resource.item!![0].initial = mutableListOf(Fhir4Questionnaire.QuestionnaireItemInitial(null))
                 resource.item!![0].initial!![0].valueAttachment = attachments[0]
@@ -314,8 +310,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         // When
@@ -323,12 +319,12 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Then
         assertEquals(
-                actual = data?.size,
-                expected = expectedSize.toInt()
+            actual = data?.size,
+            expected = expectedSize.toInt()
         )
         assertEquals(
-                actual = data!![selectFhir3Attachment(resource)],
-                expected = DATA_PAYLOAD
+            actual = data!![selectFhir3Attachment(resource)],
+            expected = DATA_PAYLOAD
         )
     }
 
@@ -338,8 +334,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
         // When
         val data = recordService.extractUploadData(resource)
@@ -347,13 +343,13 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         // Then
         if (resource !is Fhir4Observation) {
             assertEquals(
-                    actual = data!!.size,
-                    expected = expectedSize.toInt()
+                actual = data!!.size,
+                expected = expectedSize.toInt()
             )
         }
         assertEquals(
-                actual = data!![selectFhir4Attachment(resource)]!!,
-                expected = DATA_PAYLOAD
+            actual = data!![selectFhir4Attachment(resource)]!!,
+            expected = DATA_PAYLOAD
         )
     }
 
@@ -363,8 +359,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), "$resourceName-nulled-attachment")
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), "$resourceName-nulled-attachment")
         )
 
         // When
@@ -373,8 +369,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         // Then
         if (resource is Fhir3Observation && resource.component != null) {
             assertEquals(
-                    actual = data!!.size,
-                    expected = 1
+                actual = data!!.size,
+                expected = 1
             )
         } else {
             assertNull(data)
@@ -387,8 +383,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), "$resourceName-nulled-attachment")
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), "$resourceName-nulled-attachment")
         )
 
         // When
@@ -404,20 +400,20 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         val decryptedRecord = DecryptedRecord(
-                null,
-                resource,
-                null,
-                defaultAnnotations,
-                null,
-                null,
-                null,
-                null,
-                modelVersion
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            null,
+            modelVersion
         )
 
         // When
@@ -425,12 +421,12 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Then
         assertEquals(
-                actual = stripedRecord,
-                expected = decryptedRecord
+            actual = stripedRecord,
+            expected = decryptedRecord
         )
         assertEquals(
-                actual = stripedRecord.resource,
-                expected = decryptedRecord.resource
+            actual = stripedRecord.resource,
+            expected = decryptedRecord.resource
         )
         assertNull(selectFhir3Attachment(stripedRecord.resource).data)
         if (stripedRecord.resource is Fhir3Observation) {
@@ -444,20 +440,20 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
         val decryptedRecord = DecryptedR4Record(
-                null,
-                resource,
-                null,
-                defaultAnnotations,
-                null,
-                null,
-                null,
-                null,
-                modelVersion
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            null,
+            modelVersion
         )
 
         // When
@@ -465,12 +461,12 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Then
         assertEquals(
-                actual = stripedRecord,
-                expected = decryptedRecord
+            actual = stripedRecord,
+            expected = decryptedRecord
         )
         assertEquals(
-                actual = stripedRecord.resource,
-                expected = decryptedRecord.resource
+            actual = stripedRecord.resource,
+            expected = decryptedRecord.resource
         )
         assertNull(selectFhir4Attachment(stripedRecord.resource).data)
     }
@@ -481,45 +477,45 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val originalResource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         val originalPayload: HashMap<Any, String?> = hashMapOf(selectFhir3Attachment(originalResource) to DATA_PAYLOAD)
 
         val decryptedRecord = DecryptedRecord(
-                null,
-                originalResource,
-                null,
-                defaultAnnotations,
-                null,
-                null,
-                null,
-                null,
-                modelVersion
+            null,
+            originalResource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            null,
+            modelVersion
         )
 
         val stripedRecord = recordService.removeUploadData(decryptedRecord)
 
         // When
         val record = recordService.restoreUploadData(
-                stripedRecord,
-                stripedRecord.resource,
-                originalPayload
+            stripedRecord,
+            stripedRecord.resource,
+            originalPayload
         )
 
         // Then
         assertEquals(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
         assertEquals(
-                actual = record.resource,
-                expected = decryptedRecord.resource
+            actual = record.resource,
+            expected = decryptedRecord.resource
         )
         assertEquals(
-                actual = selectFhir3Attachment(record.resource).data,
-                expected = DATA_PAYLOAD
+            actual = selectFhir3Attachment(record.resource).data,
+            expected = DATA_PAYLOAD
         )
     }
 
@@ -529,58 +525,58 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val originalResource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
         val originalPayload: HashMap<Any, String?> = hashMapOf(selectFhir4Attachment(originalResource) to DATA_PAYLOAD)
 
         val decryptedRecord = DecryptedR4Record(
-                null,
-                originalResource,
-                null,
-                defaultAnnotations,
-                null,
-                null,
-                null,
-                null,
-                modelVersion
+            null,
+            originalResource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            null,
+            modelVersion
         )
 
         val stripedRecord = recordService.removeUploadData(decryptedRecord)
 
         // When
         val record = recordService.restoreUploadData(
-                stripedRecord,
-                stripedRecord.resource,
-                originalPayload
+            stripedRecord,
+            stripedRecord.resource,
+            originalPayload
         )
 
         // Then
         assertEquals(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
         assertEquals(
-                actual = record.resource,
-                expected = decryptedRecord.resource
+            actual = record.resource,
+            expected = decryptedRecord.resource
         )
         assertEquals(
-                actual = selectFhir4Attachment(record.resource).data,
-                expected = DATA_PAYLOAD
+            actual = selectFhir4Attachment(record.resource).data,
+            expected = DATA_PAYLOAD
         )
     }
 
     private fun validateFhir3CleanedIdentifiers(
-            resource: Fhir3Resource,
-            identifiers: MutableList<Fhir3Identifier>
+        resource: Fhir3Resource,
+        identifiers: MutableList<Fhir3Identifier>
     ) {
         identifiers.removeAt(1)
         when (resource) {
             is Fhir3Medication ->
                 assertEquals(
-                        actual = selectFhir3Attachment(resource).id,
-                        expected = ATTACHMENT_ID
+                    actual = selectFhir3Attachment(resource).id,
+                    expected = ATTACHMENT_ID
                 )
             is Fhir3Observation -> {
                 val expected = if (resource.component == null) {
@@ -591,40 +587,40 @@ class RecordServiceAdditionalResourceTypeModuleTest {
                 }
 
                 assertEquals(
-                        actual = resource.identifier!!.size,
-                        expected = expected
+                    actual = resource.identifier!!.size,
+                    expected = expected
                 )
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers
+                    actual = resource.identifier,
+                    expected = identifiers
                 )
             }
             is Fhir3Patient -> {
                 identifiers.removeAt(2)
                 assertEquals(
-                        actual = resource.identifier!!.size,
-                        expected = 2
+                    actual = resource.identifier!!.size,
+                    expected = 2
                 )
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers
+                    actual = resource.identifier,
+                    expected = identifiers
                 )
             }
             is Fhir3Questionnaire -> {
                 identifiers.removeAt(2)
                 assertEquals(
-                        actual = resource.identifier!!.size,
-                        expected = 2
+                    actual = resource.identifier!!.size,
+                    expected = 2
                 )
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers
+                    actual = resource.identifier,
+                    expected = identifiers
                 )
             }
             is Fhir3QuestionnaireResponse -> {
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers[0]
+                    actual = resource.identifier,
+                    expected = identifiers[0]
                 )
             }
             else -> throw RuntimeException("Unexpected resource")
@@ -637,8 +633,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         val currentIdentifier = Fhir3AttachmentHelper.buildIdentifier(ADDITIONAL_ID, ASSIGNER)
@@ -660,47 +656,47 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     }
 
     private fun validateFhir4CleanedIdentifiers(
-            resource: Fhir4Resource,
-            identifiers: MutableList<Fhir4Identifier>
+        resource: Fhir4Resource,
+        identifiers: MutableList<Fhir4Identifier>
     ) {
         identifiers.removeAt(1)
         when (resource) {
             is Fhir4Observation -> {
                 assertEquals(
-                        actual = resource.identifier!!.size,
-                        expected = 3
+                    actual = resource.identifier!!.size,
+                    expected = 3
                 )
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers
+                    actual = resource.identifier,
+                    expected = identifiers
                 )
             }
             is Fhir4Patient -> {
                 identifiers.removeAt(2)
                 assertEquals(
-                        actual = resource.identifier!!.size,
-                        expected = 2
+                    actual = resource.identifier!!.size,
+                    expected = 2
                 )
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers
+                    actual = resource.identifier,
+                    expected = identifiers
                 )
             }
             is Fhir4Questionnaire -> {
                 identifiers.removeAt(2)
                 assertEquals(
-                        actual = resource.identifier!!.size,
-                        expected = 2
+                    actual = resource.identifier!!.size,
+                    expected = 2
                 )
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers
+                    actual = resource.identifier,
+                    expected = identifiers
                 )
             }
             is Fhir4QuestionnaireResponse -> {
                 assertEquals(
-                        actual = resource.identifier,
-                        expected = identifiers[0]
+                    actual = resource.identifier,
+                    expected = identifiers[0]
                 )
             }
             else -> throw RuntimeException("Unexpected resource")
@@ -713,8 +709,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
         val currentIdentifier = Fhir4AttachmentHelper.buildIdentifier(ADDITIONAL_ID, ASSIGNER)
@@ -738,8 +734,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         val payload = PDF_ENCODED
@@ -762,8 +758,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         // Given
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
         selectFhir4Attachment(resource).data = PDF_ENCODED
@@ -780,8 +776,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         val payload = Base64.encodeToString(byteArrayOf(0))
@@ -801,8 +797,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
         selectFhir4Attachment(resource).data = Base64.encodeToString(byteArrayOf(0))
@@ -817,8 +813,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         val payload = PDF_OVERSIZED_ENCODED
@@ -838,8 +834,8 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
         selectFhir4Attachment(resource).data = PDF_OVERSIZED_ENCODED
@@ -849,14 +845,15 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         }
     }
 
+    // FHIR3 download Attachment
     @Test
-    fun `Given, downloadAttachment is called, with a Fhir3Resource, it downloads the attachment`() {
+    fun `Given, downloadFhir3Attachment is called, with a Fhir3Resource, it downloads the Attachment`() {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
         val resource = SdkFhirParser.toFhir3(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
         val fetchedRecord: EncryptedRecord = mockk()
@@ -868,16 +865,16 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         val attachmentIds = listOf(firstAttachmentId, secondAttachmentId)
 
         val firstAttachment = TestAttachmentHelper.buildFhir3Attachment(
-                firstAttachmentId,
-                DATA_PAYLOAD,
-                DATA_SIZE,
-                DATA_HASH
+            firstAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
         )
         val secondAttachment = TestAttachmentHelper.buildFhir3Attachment(
-                secondAttachmentId,
-                DATA_PAYLOAD,
-                DATA_SIZE,
-                DATA_HASH
+            secondAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
         )
 
         val attachments = listOf(firstAttachment, secondAttachment)
@@ -888,20 +885,20 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         setFhir3Id(resource, listOf(currentIdentifier))
 
         val wrappedAttachments = listOf(
-                SdkAttachmentFactory.wrap(firstAttachment),
-                SdkAttachmentFactory.wrap(secondAttachment)
+            SdkAttachmentFactory.wrap(firstAttachment),
+            SdkAttachmentFactory.wrap(secondAttachment)
         )
 
         val decryptedRecord = DecryptedRecord(
-                null,
-                resource,
-                null,
-                defaultAnnotations,
-                null,
-                null,
-                null,
-                attachmentKey,
-                modelVersion
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            attachmentKey,
+            modelVersion
         )
 
         every { recordService.decryptRecord<Fhir3Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
@@ -915,49 +912,148 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         every {
             attachmentService.download(
-                    listOf(
-                            SdkAttachmentFactory.wrap(firstAttachment),
-                            SdkAttachmentFactory.wrap(secondAttachment)
-                    ),
-                    attachmentKey,
-                    USER_ID
+                listOf(
+                    SdkAttachmentFactory.wrap(firstAttachment),
+                    SdkAttachmentFactory.wrap(secondAttachment)
+                ),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(wrappedAttachments)
 
         // When
-        val test = recordService.downloadAttachments(
-                RECORD_ID,
-                attachmentIds,
-                USER_ID,
-                DownloadType.Full
+        val test = recordService.downloadFhir3Attachments(
+            RECORD_ID,
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full
         ).test().await()
 
         // Then
         val result = test
-                .assertNoErrors()
-                .assertComplete()
-                .assertValue(listOf(wrappedAttachments[0].unwrap(), wrappedAttachments[1].unwrap()))
-                .values()[0]
+            .assertNoErrors()
+            .assertComplete()
+            .assertValue(listOf(wrappedAttachments[0].unwrap(), wrappedAttachments[1].unwrap()))
+            .values()[0]
 
         assertEquals(
-                actual = result[0].id,
-                expected = firstAttachmentId
+            actual = result[0].id,
+            expected = firstAttachmentId
         )
         assertEquals(
-                actual = result[1].id,
-                expected = secondAttachmentId
+            actual = result[1].id,
+            expected = secondAttachmentId
         )
     }
 
     @Test
-    @Ignore("Not implemented yet")
-    fun `Given, downloadAttachment is called, with a Fhir4Resource, it downloads the attachment`() {
+    fun `Given, downloadFhir3Attachments is called, with a Fhir3Resource, it downloads the Attachments`() {
+        Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
+
+        // Given
+        val resource = SdkFhirParser.toFhir3(
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+        )
+
+        val fetchedRecord: EncryptedRecord = mockk()
+        val attachmentKey: GCKey = mockk()
+
+        val firstAttachmentId = "1"
+        val secondAttachmentId = "2"
+
+        val attachmentIds = listOf(firstAttachmentId, secondAttachmentId)
+
+        val firstAttachment = TestAttachmentHelper.buildFhir3Attachment(
+            firstAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+        val secondAttachment = TestAttachmentHelper.buildFhir3Attachment(
+            secondAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+
+        val attachments = listOf(firstAttachment, secondAttachment)
+
+        val currentIdentifier = Fhir3AttachmentHelper.buildIdentifier(ADDITIONAL_ID, ASSIGNER)
+
+        setFhir3Attachment(resource, attachments)
+        setFhir3Id(resource, listOf(currentIdentifier))
+
+        val wrappedAttachments = listOf(
+            SdkAttachmentFactory.wrap(firstAttachment),
+            SdkAttachmentFactory.wrap(secondAttachment)
+        )
+
+        val decryptedRecord = DecryptedRecord(
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            attachmentKey,
+            modelVersion
+        )
+
+        every { recordService.decryptRecord<Fhir3Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
+        } returns Single.just(fetchedRecord)
+
+        every {
+            recordService.decryptRecord<Fhir3Resource>(fetchedRecord, USER_ID)
+        } returns decryptedRecord as DecryptedBaseRecord<Fhir3Resource>
+
+        every {
+            attachmentService.download(
+                listOf(
+                    SdkAttachmentFactory.wrap(firstAttachment),
+                    SdkAttachmentFactory.wrap(secondAttachment)
+                ),
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(wrappedAttachments)
+
+        // When
+        val test = recordService.downloadFhir3Attachments(
+            RECORD_ID,
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full
+        ).test().await()
+
+        // Then
+        val result = test
+            .assertNoErrors()
+            .assertComplete()
+            .assertValue(listOf(wrappedAttachments[0].unwrap(), wrappedAttachments[1].unwrap()))
+            .values()[0]
+
+        assertEquals(
+            actual = result[0].id,
+            expected = firstAttachmentId
+        )
+        assertEquals(
+            actual = result[1].id,
+            expected = secondAttachmentId
+        )
+    }
+
+    @Test
+    fun `Given, downloadFhir3Attachments is called, with a non Fhir3Resource, it fails`() {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
         val resource = SdkFhirParser.toFhir4(
-                resourceType,
-                TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
         val fetchedRecord: EncryptedRecord = mockk()
@@ -969,16 +1065,16 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         val attachmentIds = listOf(firstAttachmentId, secondAttachmentId)
 
         val firstAttachment = TestAttachmentHelper.buildFhir4Attachment(
-                firstAttachmentId,
-                DATA_PAYLOAD,
-                DATA_SIZE,
-                DATA_HASH
+            firstAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
         )
         val secondAttachment = TestAttachmentHelper.buildFhir4Attachment(
-                secondAttachmentId,
-                DATA_PAYLOAD,
-                DATA_SIZE,
-                DATA_HASH
+            secondAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
         )
 
         val attachments = listOf(firstAttachment, secondAttachment)
@@ -989,20 +1085,20 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         setFhir4Id(resource, listOf(currentIdentifier))
 
         val wrappedAttachments = listOf(
-                SdkAttachmentFactory.wrap(firstAttachment),
-                SdkAttachmentFactory.wrap(secondAttachment)
+            SdkAttachmentFactory.wrap(firstAttachment),
+            SdkAttachmentFactory.wrap(secondAttachment)
         )
 
         val decryptedRecord = DecryptedR4Record(
-                null,
-                resource,
-                null,
-                defaultAnnotations,
-                null,
-                null,
-                null,
-                attachmentKey,
-                modelVersion
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            attachmentKey,
+            modelVersion
         )
 
         every { recordService.decryptRecord<Fhir4Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
@@ -1016,37 +1112,316 @@ class RecordServiceAdditionalResourceTypeModuleTest {
 
         every {
             attachmentService.download(
-                    listOf(
-                            SdkAttachmentFactory.wrap(firstAttachment),
-                            SdkAttachmentFactory.wrap(secondAttachment)
-                    ),
-                    attachmentKey,
-                    USER_ID
+                listOf(
+                    SdkAttachmentFactory.wrap(firstAttachment),
+                    SdkAttachmentFactory.wrap(secondAttachment)
+                ),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(wrappedAttachments)
 
         // When
-        val test = recordService.downloadAttachments(
-                RECORD_ID,
-                attachmentIds,
-                USER_ID,
-                DownloadType.Full
+        val test = recordService.downloadFhir3Attachments(
+            RECORD_ID,
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full
+        ).test().await()
+
+        // Then
+        test
+            .assertError(IllegalArgumentException::class.java)
+            .assertNotComplete()
+    }
+
+    // FHIR4 download Attachment
+    @Test
+    fun `Given, downloadFhir4Attachment is called, with a Fhir4Resource, it downloads the Attachment`() {
+        Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
+
+        // Given
+        val resource = SdkFhirParser.toFhir4(
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+        )
+
+        val fetchedRecord: EncryptedRecord = mockk()
+        val attachmentKey: GCKey = mockk()
+
+        val firstAttachmentId = "1"
+        val secondAttachmentId = "2"
+
+        val attachmentIds = listOf(firstAttachmentId, secondAttachmentId)
+
+        val firstAttachment = TestAttachmentHelper.buildFhir4Attachment(
+            firstAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+        val secondAttachment = TestAttachmentHelper.buildFhir4Attachment(
+            secondAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+
+        val attachments = listOf(firstAttachment, secondAttachment)
+
+        val currentIdentifier = Fhir4AttachmentHelper.buildIdentifier(ADDITIONAL_ID, ASSIGNER)
+
+        setFhir4Attachment(resource, attachments)
+        setFhir4Id(resource, listOf(currentIdentifier))
+
+        val wrappedAttachments = listOf(
+            SdkAttachmentFactory.wrap(firstAttachment),
+            SdkAttachmentFactory.wrap(secondAttachment)
+        )
+
+        val decryptedRecord = DecryptedR4Record(
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            attachmentKey,
+            modelVersion
+        )
+
+        every { recordService.decryptRecord<Fhir4Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
+        } returns Single.just(fetchedRecord)
+
+        every {
+            recordService.decryptRecord<Fhir4Resource>(fetchedRecord, USER_ID)
+        } returns decryptedRecord as DecryptedBaseRecord<Fhir4Resource>
+
+        every {
+            attachmentService.download(
+                listOf(
+                    SdkAttachmentFactory.wrap(firstAttachment),
+                    SdkAttachmentFactory.wrap(secondAttachment)
+                ),
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(wrappedAttachments)
+
+        // When
+        val test = recordService.downloadFhir4Attachments(
+            RECORD_ID,
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full
         ).test().await()
 
         // Then
         val result = test
-                .assertNoErrors()
-                .assertComplete()
-                .assertValue(listOf(wrappedAttachments[0].unwrap(), wrappedAttachments[1].unwrap()))
-                .values()[0]
+            .assertNoErrors()
+            .assertComplete()
+            .assertValue(listOf(wrappedAttachments[0].unwrap(), wrappedAttachments[1].unwrap()))
+            .values()[0]
 
         assertEquals(
-                actual = result[0].id,
-                expected = firstAttachmentId
+            actual = result[0].id,
+            expected = firstAttachmentId
         )
         assertEquals(
-                actual = result[1].id,
-                expected = secondAttachmentId
+            actual = result[1].id,
+            expected = secondAttachmentId
         )
+    }
+
+    @Test
+    fun `Given, downloadFhir4Attachments is called, with a Fhir4Resource, it downloads the Attachments`() {
+        Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
+
+        // Given
+        val resource = SdkFhirParser.toFhir4(
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
+        )
+
+        val fetchedRecord: EncryptedRecord = mockk()
+        val attachmentKey: GCKey = mockk()
+
+        val firstAttachmentId = "1"
+        val secondAttachmentId = "2"
+
+        val attachmentIds = listOf(firstAttachmentId, secondAttachmentId)
+
+        val firstAttachment = TestAttachmentHelper.buildFhir4Attachment(
+            firstAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+        val secondAttachment = TestAttachmentHelper.buildFhir4Attachment(
+            secondAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+
+        val attachments = listOf(firstAttachment, secondAttachment)
+
+        val currentIdentifier = Fhir4AttachmentHelper.buildIdentifier(ADDITIONAL_ID, ASSIGNER)
+
+        setFhir4Attachment(resource, attachments)
+        setFhir4Id(resource, listOf(currentIdentifier))
+
+        val wrappedAttachments = listOf(
+            SdkAttachmentFactory.wrap(firstAttachment),
+            SdkAttachmentFactory.wrap(secondAttachment)
+        )
+
+        val decryptedRecord = DecryptedR4Record(
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            attachmentKey,
+            modelVersion
+        )
+
+        every { recordService.decryptRecord<Fhir4Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
+        } returns Single.just(fetchedRecord)
+
+        every {
+            recordService.decryptRecord<Fhir4Resource>(fetchedRecord, USER_ID)
+        } returns decryptedRecord as DecryptedBaseRecord<Fhir4Resource>
+
+        every {
+            attachmentService.download(
+                listOf(
+                    SdkAttachmentFactory.wrap(firstAttachment),
+                    SdkAttachmentFactory.wrap(secondAttachment)
+                ),
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(wrappedAttachments)
+
+        // When
+        val test = recordService.downloadFhir4Attachments(
+            RECORD_ID,
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full
+        ).test().await()
+
+        // Then
+        val result = test
+            .assertNoErrors()
+            .assertComplete()
+            .assertValue(listOf(wrappedAttachments[0].unwrap(), wrappedAttachments[1].unwrap()))
+            .values()[0]
+
+        assertEquals(
+            actual = result[0].id,
+            expected = firstAttachmentId
+        )
+        assertEquals(
+            actual = result[1].id,
+            expected = secondAttachmentId
+        )
+    }
+
+    @Test
+    fun `Given, downloadFhir4Attachments is called, with a non Fhir4Resource, it fails`() {
+        Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
+
+        // Given
+        val resource = SdkFhirParser.toFhir3(
+            resourceType,
+            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
+        )
+
+        val fetchedRecord: EncryptedRecord = mockk()
+        val attachmentKey: GCKey = mockk()
+
+        val firstAttachmentId = "1"
+        val secondAttachmentId = "2"
+
+        val attachmentIds = listOf(firstAttachmentId, secondAttachmentId)
+
+        val firstAttachment = TestAttachmentHelper.buildFhir3Attachment(
+            firstAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+        val secondAttachment = TestAttachmentHelper.buildFhir3Attachment(
+            secondAttachmentId,
+            DATA_PAYLOAD,
+            DATA_SIZE,
+            DATA_HASH
+        )
+
+        val attachments = listOf(firstAttachment, secondAttachment)
+
+        val currentIdentifier = Fhir3AttachmentHelper.buildIdentifier(ADDITIONAL_ID, ASSIGNER)
+
+        setFhir3Attachment(resource, attachments)
+        setFhir3Id(resource, listOf(currentIdentifier))
+
+        val wrappedAttachments = listOf(
+            SdkAttachmentFactory.wrap(firstAttachment),
+            SdkAttachmentFactory.wrap(secondAttachment)
+        )
+
+        val decryptedRecord = DecryptedRecord(
+            null,
+            resource,
+            null,
+            defaultAnnotations,
+            null,
+            null,
+            null,
+            attachmentKey,
+            modelVersion
+        )
+
+        every { recordService.decryptRecord<Fhir3Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
+        } returns Single.just(fetchedRecord)
+
+        every {
+            recordService.decryptRecord<Fhir3Resource>(fetchedRecord, USER_ID)
+        } returns decryptedRecord as DecryptedBaseRecord<Fhir3Resource>
+
+        every {
+            attachmentService.download(
+                listOf(
+                    SdkAttachmentFactory.wrap(firstAttachment),
+                    SdkAttachmentFactory.wrap(secondAttachment)
+                ),
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(wrappedAttachments)
+
+        // When
+        val test = recordService.downloadFhir4Attachments(
+            RECORD_ID,
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full
+        ).test().await()
+
+        // Then
+        test
+            .assertError(IllegalArgumentException::class.java)
+            .assertNotComplete()
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentDownloadTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentDownloadTest.kt
@@ -119,6 +119,8 @@ class RecordServiceAttachmentDownloadTest {
         every { decryptedRecord.resource } returns resource
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
+
 
         // When
         val record = recordService.downloadData(decryptedRecord, USER_ID)
@@ -130,6 +132,7 @@ class RecordServiceAttachmentDownloadTest {
         )
 
         verify { attachmentService.download(any(), any(), any()) wasNot Called }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test
@@ -358,6 +361,7 @@ class RecordServiceAttachmentDownloadTest {
         every { decryptedRecord.resource } returns resource
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val record = recordService.downloadData(decryptedRecord, USER_ID)
@@ -369,6 +373,7 @@ class RecordServiceAttachmentDownloadTest {
         )
 
         verify { attachmentService.download(any(), any(), any()) wasNot Called }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentDownloadTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentDownloadTest.kt
@@ -17,9 +17,6 @@
 package care.data4life.sdk
 
 import care.data4life.crypto.GCKey
-import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
-import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.data.DataResource
@@ -31,6 +28,9 @@ import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.DataValidationException
 import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
 import care.data4life.sdk.tag.TaggingContract
+import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
+import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.wrapper.SdkAttachmentFactory
 import care.data4life.sdk.wrapper.SdkFhirAttachmentHelper
 import care.data4life.sdk.wrapper.WrapperContract
@@ -66,18 +66,18 @@ class RecordServiceAttachmentDownloadTest {
         clearAllMocks()
 
         recordService = spyk(
-                RecordService(
-                        PARTNER_ID,
-                        ALIAS,
-                        apiService,
-                        tagEncryptionService,
-                        taggingService,
-                        fhirService,
-                        attachmentService,
-                        cryptoService,
-                        errorHandler,
-                        mockk()
-                )
+            RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler,
+                mockk()
+            )
         )
 
         mockkObject(SdkFhirAttachmentHelper)
@@ -103,8 +103,8 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.download(any(), any(), any()) wasNot Called }
@@ -121,14 +121,13 @@ class RecordServiceAttachmentDownloadTest {
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
         every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
-
         // When
         val record = recordService.downloadData(decryptedRecord, USER_ID)
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.download(any(), any(), any()) wasNot Called }
@@ -151,8 +150,8 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.download(any(), any(), any()) wasNot Called }
@@ -166,7 +165,7 @@ class RecordServiceAttachmentDownloadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
 
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         val wrappedAttachment: WrapperContract.Attachment = spyk()
@@ -187,8 +186,8 @@ class RecordServiceAttachmentDownloadTest {
         }
 
         assertEquals(
-                actual = error.message,
-                expected = "Attachment.id expected"
+            actual = error.message,
+            expected = "Attachment.id expected"
         )
     }
 
@@ -200,7 +199,7 @@ class RecordServiceAttachmentDownloadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
 
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         val wrappedAttachment: WrapperContract.Attachment = spyk()
@@ -216,9 +215,9 @@ class RecordServiceAttachmentDownloadTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(mockk())
 
@@ -227,15 +226,15 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
     }
@@ -248,7 +247,7 @@ class RecordServiceAttachmentDownloadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
 
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         val wrappedAttachment: WrapperContract.Attachment = spyk()
@@ -267,9 +266,9 @@ class RecordServiceAttachmentDownloadTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(mockk())
 
@@ -278,17 +277,17 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
     }
@@ -318,9 +317,9 @@ class RecordServiceAttachmentDownloadTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(mockk())
 
@@ -329,25 +328,25 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
 
         verify(exactly = 1) {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
     }
@@ -368,8 +367,8 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.download(any(), any(), any()) wasNot Called }
@@ -392,8 +391,8 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.download(any(), any(), any()) wasNot Called }
@@ -407,7 +406,7 @@ class RecordServiceAttachmentDownloadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
 
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         val wrappedAttachment: WrapperContract.Attachment = spyk()
@@ -428,8 +427,8 @@ class RecordServiceAttachmentDownloadTest {
         }
 
         assertEquals(
-                actual = error.message,
-                expected = "Attachment.id expected"
+            actual = error.message,
+            expected = "Attachment.id expected"
         )
     }
 
@@ -441,7 +440,7 @@ class RecordServiceAttachmentDownloadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
 
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         val wrappedAttachment: WrapperContract.Attachment = spyk()
@@ -457,9 +456,9 @@ class RecordServiceAttachmentDownloadTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(mockk())
 
@@ -468,15 +467,15 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
     }
@@ -506,9 +505,9 @@ class RecordServiceAttachmentDownloadTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(mockk())
 
@@ -517,25 +516,25 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
 
         verify(exactly = 1) {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
     }
@@ -548,7 +547,7 @@ class RecordServiceAttachmentDownloadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
 
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         val wrappedAttachment: WrapperContract.Attachment = spyk()
@@ -567,9 +566,9 @@ class RecordServiceAttachmentDownloadTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(mockk())
 
@@ -578,17 +577,17 @@ class RecordServiceAttachmentDownloadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey
             attachmentService.download(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         }
     }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
@@ -16,8 +16,6 @@
 
 package care.data4life.sdk
 
-import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
-import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.attachment.ThumbnailService
 import care.data4life.sdk.attachment.ThumbnailService.Companion.SPLIT_CHAR
@@ -36,6 +34,8 @@ import care.data4life.sdk.record.RecordContract.Service.Companion.DOWNSCALED_ATT
 import care.data4life.sdk.record.RecordContract.Service.Companion.PREVIEW_ID_POS
 import care.data4life.sdk.record.RecordContract.Service.Companion.THUMBNAIL_ID_POS
 import care.data4life.sdk.tag.TaggingContract
+import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
+import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
 import care.data4life.sdk.wrapper.SdkAttachmentFactory
 import care.data4life.sdk.wrapper.SdkFhirAttachmentHelper
 import care.data4life.sdk.wrapper.SdkIdentifierFactory
@@ -73,18 +73,18 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         clearAllMocks()
 
         recordService = spyk(
-                RecordService(
-                        PARTNER_ID,
-                        ALIAS,
-                        apiService,
-                        tagEncryptionService,
-                        taggingService,
-                        fhirService,
-                        attachmentService,
-                        cryptoService,
-                        errorHandler,
-                        mockk()
-                )
+            RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler,
+                mockk()
+            )
         )
 
         mockkObject(SdkFhirAttachmentHelper)
@@ -141,8 +141,8 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         }
 
         assertEquals(
-                actual = error.message,
-                expected = DOWNSCALED_ATTACHMENT_IDS_FMT
+            actual = error.message,
+            expected = DOWNSCALED_ATTACHMENT_IDS_FMT
         )
     }
 
@@ -151,10 +151,10 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         // Given
         val additionalIdentifier: WrapperContract.Identifier = mockk()
         val value = listOf(
-                DOWNSCALED_ATTACHMENT_IDS_FMT,
-                "potato",
-                "tomato",
-                "soup"
+            DOWNSCALED_ATTACHMENT_IDS_FMT,
+            "potato",
+            "tomato",
+            "soup"
         )
 
         every { additionalIdentifier.value } returns value.joinToString(ThumbnailService.SPLIT_CHAR)
@@ -164,8 +164,8 @@ class RecordServiceAttachmentIdentifierUtilsTest {
 
         // Then
         assertEquals(
-                actual = parts,
-                expected = value
+            actual = parts,
+            expected = value
         )
     }
 
@@ -218,7 +218,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         // Given
         val resource: Fhir3Resource = mockk()
         val attachments: MutableList<Fhir3Attachment?> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
@@ -237,7 +237,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         // Given
         val resource: Fhir3Resource = mockk(relaxed = true)
         val attachments: MutableList<Fhir3Attachment?> = mutableListOf(
-                mockk()
+            mockk()
         )
         val identifiers: MutableList<Fhir3Identifier> = mutableListOf()
 
@@ -265,12 +265,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir3Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -307,12 +307,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir3Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
         val splittedIdentifier = listOf("any", attachmentId)
@@ -350,12 +350,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir3Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
         val splittedIdentifier = listOf("any", "any")
@@ -393,13 +393,13 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir3Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
         val splittedIdentifier = listOf("any", attachmentId)
@@ -468,7 +468,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         // Given
         val resource: Fhir4Resource = mockk()
         val attachments: MutableList<Fhir4Attachment?> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
@@ -487,7 +487,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         // Given
         val resource: Fhir4Resource = mockk(relaxed = true)
         val attachments: MutableList<Fhir4Attachment?> = mutableListOf(
-                mockk()
+            mockk()
         )
         val identifiers: MutableList<Fhir4Identifier> = mutableListOf()
 
@@ -515,12 +515,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir4Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -557,12 +557,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir4Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
         val splittedIdentifier = listOf("any", attachmentId)
@@ -600,12 +600,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir4Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
         val splittedIdentifier = listOf("any", "any")
@@ -643,13 +643,13 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val attachmentId = "id"
         val attachments: MutableList<Any?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = mockk()
 
         val identifiers: MutableList<Fhir4Identifier> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
         val splittedIdentifier = listOf("any", attachmentId)
@@ -684,7 +684,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     @Test
     fun `Given, extractAdditionalAttachmentIds a null and an AttachmentId, it returns null`() {
         assertNull(
-                recordService.extractAdditionalAttachmentIds(null, "any")
+            recordService.extractAdditionalAttachmentIds(null, "any")
         )
     }
 
@@ -692,7 +692,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, extractAdditionalAttachmentIds a list of Fhir3Identifier and an AttachmentId, it returns null, if no part of a Identifier is splittable`() {
         // Given
         val identifiers: List<Fhir3Identifier> = listOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -712,7 +712,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, extractAdditionalAttachmentIds a list of Fhir3Identifier and an AttachmentId, it returns null, if no part of a Identifier matches the AttachmentId`() {
         // Given
         val identifiers: List<Fhir3Identifier> = listOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -733,7 +733,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, extractAdditionalAttachmentIds a list of Fhir3Identifier and an AttachmentId, it returns the first parts of a Identifier, which match the AttachmentId`() {
         // Given
         val identifiers: List<Fhir3Identifier> = listOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -748,8 +748,8 @@ class RecordServiceAttachmentIdentifierUtilsTest {
 
         // Then
         assertSame(
-                actual = extracted,
-                expected = parts
+            actual = extracted,
+            expected = parts
         )
     }
 
@@ -757,7 +757,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, extractAdditionalAttachmentIds a list of Fhir4Identifier and an AttachmentId, it returns null, if no part of a Identifier is splittable`() {
         // Given
         val identifiers: List<Fhir4Identifier> = listOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -777,7 +777,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, extractAdditionalAttachmentIds a list of Fhir4Identifier and an AttachmentId, it returns null, if no part of a Identifier matches the AttachmentId`() {
         // Given
         val identifiers: List<Fhir4Identifier> = listOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -798,7 +798,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, extractAdditionalAttachmentIds a list of Fhir4Identifier and an AttachmentId, it returns the first parts of a Identifier, which match the AttachmentId`() {
         // Given
         val identifiers: List<Fhir4Identifier> = listOf(
-                mockk()
+            mockk()
         )
         val wrappedIdentifier: WrapperContract.Identifier = mockk()
 
@@ -813,8 +813,8 @@ class RecordServiceAttachmentIdentifierUtilsTest {
 
         // Then
         assertSame(
-                actual = extracted,
-                expected = parts
+            actual = extracted,
+            expected = parts
         )
     }
 
@@ -822,7 +822,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir3Identifier and a DownloadType, it does nothing, if the extracted Ids are null`() {
         // When
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir3Identifier> = mockk()
@@ -832,16 +832,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns null
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Small
+            attachments,
+            identifiers,
+            DownloadType.Small
         )
 
         // Then
@@ -853,7 +853,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         // When
         val extracted: List<String> = mockk()
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir3Identifier> = mockk()
@@ -863,16 +863,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns extracted
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Full
+            attachments,
+            identifiers,
+            DownloadType.Full
         )
 
         // Then
@@ -883,13 +883,13 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir3Identifier and a DownloadType, it adds PREVIEW_ID_POS to the AttachmentId, if DownloadType is MEDIUM`() {
         // When
         val extracted: List<String> = listOf(
-                "tomato",
-                "potato",
-                "cucumber",
-                "soup"
+            "tomato",
+            "potato",
+            "cucumber",
+            "soup"
         )
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir3Identifier> = mockk()
@@ -902,16 +902,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns extracted
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Medium
+            attachments,
+            identifiers,
+            DownloadType.Medium
         )
 
         // Then
@@ -924,13 +924,13 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir3Identifier and a DownloadType, it adds THUMBNAIL_ID_POS to the AttachmentId, if DownloadType is SMALL`() {
         // When
         val extracted: List<String> = listOf(
-                "tomato",
-                "potato",
-                "cucumber",
-                "soup"
+            "tomato",
+            "potato",
+            "cucumber",
+            "soup"
         )
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir3Identifier> = mockk()
@@ -943,16 +943,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns extracted
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Small
+            attachments,
+            identifiers,
+            DownloadType.Small
         )
 
         // Then
@@ -965,7 +965,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir4Identifier and a DownloadType, it does nothing, if the extracted Ids are null`() {
         // When
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir4Identifier> = mockk()
@@ -975,16 +975,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns null
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Small
+            attachments,
+            identifiers,
+            DownloadType.Small
         )
 
         // Then
@@ -996,7 +996,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         // When
         val extracted: List<String> = mockk()
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir4Identifier> = mockk()
@@ -1006,16 +1006,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns extracted
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Full
+            attachments,
+            identifiers,
+            DownloadType.Full
         )
 
         // Then
@@ -1026,13 +1026,13 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir4Identifier and a DownloadType, it adds PREVIEW_ID_POS to the AttachmentId, if DownloadType is MEDIUM`() {
         // When
         val extracted: List<String> = listOf(
-                "tomato",
-                "potato",
-                "cucumber",
-                "soup"
+            "tomato",
+            "potato",
+            "cucumber",
+            "soup"
         )
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir4Identifier> = mockk()
@@ -1045,16 +1045,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns extracted
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Medium
+            attachments,
+            identifiers,
+            DownloadType.Medium
         )
 
         // Then
@@ -1067,13 +1067,13 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir4Identifier and a DownloadType, it adds THUMBNAIL_ID_POS to the AttachmentId, if DownloadType is SMALL`() {
         // When
         val extracted: List<String> = listOf(
-                "tomato",
-                "potato",
-                "cucumber",
-                "soup"
+            "tomato",
+            "potato",
+            "cucumber",
+            "soup"
         )
         val attachments: List<WrapperContract.Attachment> = listOf(
-                mockk()
+            mockk()
         )
         val attachmentId = "id"
         val identifiers: List<Fhir4Identifier> = mockk()
@@ -1086,16 +1086,16 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
-                    identifiers,
-                    attachmentId
+                identifiers,
+                attachmentId
             )
         } returns extracted
 
         // When
         recordService.setAttachmentIdForDownloadType(
-                attachments,
-                identifiers,
-                DownloadType.Small
+            attachments,
+            identifiers,
+            DownloadType.Small
         )
 
         // Then

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
@@ -187,14 +187,14 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         recordService.cleanObsoleteAdditionalIdentifiers(resource)
 
         // Then
         verify(exactly = 0) { SdkFhirAttachmentHelper.getIdentifier(any()) }
-        verify(exactly = 0) { SdkFhirAttachmentHelper.getAttachment(resource) }
+        verify(exactly = 0) { SdkFhirAttachmentHelper.getAttachment(any()) }
     }
 
     @Test
@@ -437,14 +437,14 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         recordService.cleanObsoleteAdditionalIdentifiers(resource)
 
         // Then
         verify(exactly = 0) { SdkFhirAttachmentHelper.getIdentifier(any()) }
-        verify(exactly = 0) { SdkFhirAttachmentHelper.getAttachment(resource) }
+        verify(exactly = 0) { SdkFhirAttachmentHelper.getAttachment(any()) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
@@ -819,18 +819,17 @@ class RecordServiceAttachmentIdentifierUtilsTest {
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir3Attachments, a list of Fhir3Identifier and a DownloadType, it does nothing, if the extracted Ids are null`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir3Identifier and a DownloadType, it does nothing, if the extracted Ids are null`() {
         // When
-        val attachments: List<Fhir3Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir3Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -846,23 +845,22 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         )
 
         // Then
-        verify(exactly = 0) { wrappedAttachment.id = any() }
+        verify(exactly = 0) { attachments[0].id = any() }
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir3Attachments, a list of Fhir3Identifier and a DownloadType, it does nothing, if DownloadType is FULL`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir3Identifier and a DownloadType, it does nothing, if DownloadType is FULL`() {
         // When
         val extracted: List<String> = mockk()
-        val attachments: List<Fhir3Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir3Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -878,11 +876,11 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         )
 
         // Then
-        verify(exactly = 0) { wrappedAttachment.id = any() }
+        verify(exactly = 0) { attachments[0].id = any() }
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir3Attachments, a list of Fhir3Identifier and a DownloadType, it adds PREVIEW_ID_POS to the AttachmentId, if DownloadType is MEDIUM`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir3Identifier and a DownloadType, it adds PREVIEW_ID_POS to the AttachmentId, if DownloadType is MEDIUM`() {
         // When
         val extracted: List<String> = listOf(
                 "tomato",
@@ -890,19 +888,18 @@ class RecordServiceAttachmentIdentifierUtilsTest {
                 "cucumber",
                 "soup"
         )
-        val attachments: List<Fhir3Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir3Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
         every {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
         } just Runs
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -919,12 +916,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
 
         // Then
         verify(exactly = 1) {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
         }
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir3Attachments, a list of Fhir3Identifier and a DownloadType, it adds THUMBNAIL_ID_POS to the AttachmentId, if DownloadType is SMALL`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir3Identifier and a DownloadType, it adds THUMBNAIL_ID_POS to the AttachmentId, if DownloadType is SMALL`() {
         // When
         val extracted: List<String> = listOf(
                 "tomato",
@@ -932,19 +929,18 @@ class RecordServiceAttachmentIdentifierUtilsTest {
                 "cucumber",
                 "soup"
         )
-        val attachments: List<Fhir3Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir3Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
         every {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
         } just Runs
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -961,23 +957,22 @@ class RecordServiceAttachmentIdentifierUtilsTest {
 
         // Then
         verify(exactly = 1) {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
         }
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir4Attachments, a list of Fhir4Identifier and a DownloadType, it does nothing, if the extracted Ids are null`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir4Identifier and a DownloadType, it does nothing, if the extracted Ids are null`() {
         // When
-        val attachments: List<Fhir4Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir4Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -993,23 +988,22 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         )
 
         // Then
-        verify(exactly = 0) { wrappedAttachment.id = any() }
+        verify(exactly = 0) { attachments[0].id = any() }
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir4Attachments, a list of Fhir4Identifier and a DownloadType, it does nothing, if DownloadType is FULL`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir4Identifier and a DownloadType, it does nothing, if DownloadType is FULL`() {
         // When
         val extracted: List<String> = mockk()
-        val attachments: List<Fhir4Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir4Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -1025,11 +1019,11 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         )
 
         // Then
-        verify(exactly = 0) { wrappedAttachment.id = any() }
+        verify(exactly = 0) { attachments[0].id = any() }
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir4Attachments, a list of Fhir4Identifier and a DownloadType, it adds PREVIEW_ID_POS to the AttachmentId, if DownloadType is MEDIUM`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir4Identifier and a DownloadType, it adds PREVIEW_ID_POS to the AttachmentId, if DownloadType is MEDIUM`() {
         // When
         val extracted: List<String> = listOf(
                 "tomato",
@@ -1037,19 +1031,18 @@ class RecordServiceAttachmentIdentifierUtilsTest {
                 "cucumber",
                 "soup"
         )
-        val attachments: List<Fhir4Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir4Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
         every {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
         } just Runs
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -1066,12 +1059,12 @@ class RecordServiceAttachmentIdentifierUtilsTest {
 
         // Then
         verify(exactly = 1) {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[PREVIEW_ID_POS]
         }
     }
 
     @Test
-    fun `Given, setAttachmentIdForDownloadType is called with a list of Fhir4Attachments, a list of Fhir4Identifier and a DownloadType, it adds THUMBNAIL_ID_POS to the AttachmentId, if DownloadType is SMALL`() {
+    fun `Given, setAttachmentIdForDownloadType is called with a list of wrapped Attachments, a list of Fhir4Identifier and a DownloadType, it adds THUMBNAIL_ID_POS to the AttachmentId, if DownloadType is SMALL`() {
         // When
         val extracted: List<String> = listOf(
                 "tomato",
@@ -1079,19 +1072,18 @@ class RecordServiceAttachmentIdentifierUtilsTest {
                 "cucumber",
                 "soup"
         )
-        val attachments: List<Fhir4Attachment> = listOf(
+        val attachments: List<WrapperContract.Attachment> = listOf(
                 mockk()
         )
         val attachmentId = "id"
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
         val identifiers: List<Fhir4Identifier> = mockk()
 
-        every { wrappedAttachment.id } returns attachmentId
+        every { attachments[0].id } returns attachmentId
         every {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
         } just Runs
 
-        every { SdkAttachmentFactory.wrap(attachments[0]) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(attachments[0]) } returns attachments[0]
         every {
             recordService.extractAdditionalAttachmentIds(
                     identifiers,
@@ -1108,7 +1100,7 @@ class RecordServiceAttachmentIdentifierUtilsTest {
 
         // Then
         verify(exactly = 1) {
-            wrappedAttachment.id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
+            attachments[0].id = attachmentId + SPLIT_CHAR + extracted[THUMBNAIL_ID_POS]
         }
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUpdateTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUpdateTest.kt
@@ -145,6 +145,7 @@ class RecordServiceAttachmentUpdateTest {
 
         every { decryptedRecord.resource } returns oldResource
         every { SdkFhirAttachmentHelper.hasAttachment(oldResource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val record = recordService.updateData(
@@ -168,6 +169,7 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         verify { attachmentService.upload(any(), any(), any()) wasNot Called }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUpdateTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUpdateTest.kt
@@ -17,9 +17,6 @@
 package care.data4life.sdk
 
 import care.data4life.crypto.GCKey
-import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
-import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.data.DataResource
@@ -32,6 +29,9 @@ import care.data4life.sdk.lang.CoreRuntimeException
 import care.data4life.sdk.lang.DataValidationException
 import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
 import care.data4life.sdk.tag.TaggingContract
+import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
+import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.wrapper.SdkAttachmentFactory
 import care.data4life.sdk.wrapper.SdkFhirAttachmentHelper
 import care.data4life.sdk.wrapper.WrapperContract
@@ -67,18 +67,18 @@ class RecordServiceAttachmentUpdateTest {
         clearAllMocks()
 
         recordService = spyk(
-                RecordService(
-                        PARTNER_ID,
-                        ALIAS,
-                        apiService,
-                        tagEncryptionService,
-                        taggingService,
-                        fhirService,
-                        attachmentService,
-                        cryptoService,
-                        errorHandler,
-                        mockk()
-                )
+            RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler,
+                mockk()
+            )
         )
 
         mockkObject(SdkFhirAttachmentHelper)
@@ -102,15 +102,15 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         val record = recordService.updateData(
-                decryptedRecord,
-                newResource,
-                USER_ID
+            decryptedRecord,
+            newResource,
+            USER_ID
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.upload(any(), any(), any()) wasNot Called }
@@ -129,9 +129,9 @@ class RecordServiceAttachmentUpdateTest {
         assertFailsWith<CoreRuntimeException.UnsupportedOperation> {
             // When
             recordService.updateData(
-                    decryptedRecord,
-                    newResource,
-                    USER_ID
+                decryptedRecord,
+                newResource,
+                USER_ID
             )
         }
     }
@@ -149,22 +149,22 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         val record = recordService.updateData(
-                decryptedRecord,
-                newResource,
-                USER_ID
+            decryptedRecord,
+            newResource,
+            USER_ID
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.updateData(
-                    decryptedRecord,
-                    newResource,
-                    USER_ID
+                decryptedRecord,
+                newResource,
+                USER_ID
             )
         }
 
@@ -180,7 +180,7 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
@@ -199,8 +199,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -212,7 +212,7 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
@@ -232,8 +232,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -245,7 +245,7 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
@@ -266,8 +266,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash is not valid"
+            actual = exception.message,
+            expected = "Attachment.hash is not valid"
         )
     }
 
@@ -279,12 +279,12 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val oldAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
@@ -311,8 +311,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Valid Attachment.id expected"
+            actual = exception.message,
+            expected = "Valid Attachment.id expected"
         )
     }
 
@@ -326,12 +326,12 @@ class RecordServiceAttachmentUpdateTest {
         val hash = "hash"
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedNewAttachment.hash } returns hash
@@ -348,15 +348,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -365,16 +365,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -390,13 +390,13 @@ class RecordServiceAttachmentUpdateTest {
         val hash = "hash"
 
         val newAttachments: MutableList<Fhir3Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedNewAttachment.hash } returns hash
@@ -413,15 +413,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -430,16 +430,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -455,12 +455,12 @@ class RecordServiceAttachmentUpdateTest {
         val hash = "hash"
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedNewAttachment.hash } returns hash
@@ -480,15 +480,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -497,8 +497,8 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -506,9 +506,9 @@ class RecordServiceAttachmentUpdateTest {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey = attachmentKey
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -525,17 +525,17 @@ class RecordServiceAttachmentUpdateTest {
         val id = "id"
 
         val oldAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedOldAttachment.id } returns id
@@ -561,15 +561,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -578,8 +578,8 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -599,17 +599,17 @@ class RecordServiceAttachmentUpdateTest {
         val id = "id"
 
         val oldAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedOldAttachment.id } returns id
@@ -635,15 +635,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -652,16 +652,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -678,17 +678,17 @@ class RecordServiceAttachmentUpdateTest {
         val id = "id"
 
         val oldAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedOldAttachment.id } returns id
@@ -714,15 +714,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -731,16 +731,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -759,9 +759,9 @@ class RecordServiceAttachmentUpdateTest {
         assertFailsWith<CoreRuntimeException.UnsupportedOperation> {
             // When
             recordService.updateData(
-                    decryptedRecord,
-                    newResource,
-                    USER_ID
+                decryptedRecord,
+                newResource,
+                USER_ID
             )
         }
     }
@@ -778,22 +778,22 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         val record = recordService.updateData(
-                decryptedRecord,
-                newResource,
-                USER_ID
+            decryptedRecord,
+            newResource,
+            USER_ID
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.updateData(
-                    decryptedRecord,
-                    newResource,
-                    USER_ID
+                decryptedRecord,
+                newResource,
+                USER_ID
             )
         }
 
@@ -808,7 +808,7 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
@@ -827,8 +827,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -840,7 +840,7 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
@@ -860,8 +860,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -873,7 +873,7 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
@@ -894,8 +894,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash is not valid"
+            actual = exception.message,
+            expected = "Attachment.hash is not valid"
         )
     }
 
@@ -907,12 +907,12 @@ class RecordServiceAttachmentUpdateTest {
         val decryptedRecord: DecryptedBaseRecord<Any> = mockk()
 
         val oldAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
@@ -939,8 +939,8 @@ class RecordServiceAttachmentUpdateTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Valid Attachment.id expected"
+            actual = exception.message,
+            expected = "Valid Attachment.id expected"
         )
     }
 
@@ -954,12 +954,12 @@ class RecordServiceAttachmentUpdateTest {
         val hash = "hash"
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedNewAttachment.hash } returns hash
@@ -976,15 +976,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -993,16 +993,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -1018,13 +1018,13 @@ class RecordServiceAttachmentUpdateTest {
         val hash = "hash"
 
         val newAttachments: MutableList<Fhir4Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedNewAttachment.hash } returns hash
@@ -1041,15 +1041,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -1058,16 +1058,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -1083,12 +1083,12 @@ class RecordServiceAttachmentUpdateTest {
         val hash = "hash"
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedNewAttachment.hash } returns hash
@@ -1108,15 +1108,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -1125,8 +1125,8 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -1134,9 +1134,9 @@ class RecordServiceAttachmentUpdateTest {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey = attachmentKey
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -1153,17 +1153,17 @@ class RecordServiceAttachmentUpdateTest {
         val id = "id"
 
         val oldAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedOldAttachment.id } returns id
@@ -1189,15 +1189,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -1206,8 +1206,8 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -1227,17 +1227,17 @@ class RecordServiceAttachmentUpdateTest {
         val id = "id"
 
         val oldAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedOldAttachment.id } returns id
@@ -1263,15 +1263,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -1280,16 +1280,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }
@@ -1306,17 +1306,17 @@ class RecordServiceAttachmentUpdateTest {
         val id = "id"
 
         val oldAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedOldAttachment: WrapperContract.Attachment = spyk()
 
         val newAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedNewAttachment: WrapperContract.Attachment = spyk()
 
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { wrappedOldAttachment.id } returns id
@@ -1342,15 +1342,15 @@ class RecordServiceAttachmentUpdateTest {
 
         every {
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    newResource,
-                    updatedAttachments
+                newResource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -1359,16 +1359,16 @@ class RecordServiceAttachmentUpdateTest {
 
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedNewAttachment)
             attachmentService.upload(
-                    listOf(wrappedNewAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedNewAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(newResource, updatedAttachments)
         }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUploadTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUploadTest.kt
@@ -122,6 +122,7 @@ class RecordServiceAttachmentUploadTest {
 
         every { decryptedRecord.resource } returns resource
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val record = recordService.uploadData(decryptedRecord, USER_ID)
@@ -501,6 +502,7 @@ class RecordServiceAttachmentUploadTest {
 
         every { decryptedRecord.resource } returns resource
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val record = recordService.uploadData(decryptedRecord, USER_ID)
@@ -516,6 +518,7 @@ class RecordServiceAttachmentUploadTest {
         }
 
         verify { attachmentService.upload(any(), any(), any()) wasNot Called }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUploadTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUploadTest.kt
@@ -17,9 +17,6 @@
 package care.data4life.sdk
 
 import care.data4life.crypto.GCKey
-import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
-import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.data.DataResource
@@ -31,6 +28,9 @@ import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.DataValidationException
 import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
 import care.data4life.sdk.tag.TaggingContract
+import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
+import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.wrapper.SdkAttachmentFactory
 import care.data4life.sdk.wrapper.SdkFhirAttachmentHelper
 import care.data4life.sdk.wrapper.WrapperContract
@@ -66,18 +66,18 @@ class RecordServiceAttachmentUploadTest {
         clearAllMocks()
 
         recordService = spyk(
-                RecordService(
-                        PARTNER_ID,
-                        ALIAS,
-                        apiService,
-                        tagEncryptionService,
-                        taggingService,
-                        fhirService,
-                        attachmentService,
-                        cryptoService,
-                        errorHandler,
-                        mockk()
-                )
+            RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler,
+                mockk()
+            )
         )
 
         mockkObject(SdkFhirAttachmentHelper)
@@ -103,8 +103,8 @@ class RecordServiceAttachmentUploadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -129,8 +129,8 @@ class RecordServiceAttachmentUploadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -155,8 +155,8 @@ class RecordServiceAttachmentUploadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.upload(any(), any(), any()) wasNot Called }
@@ -168,7 +168,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val rawAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -186,8 +186,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.id should be null"
+            actual = exception.message,
+            expected = "Attachment.id should be null"
         )
     }
 
@@ -197,7 +197,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val rawAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -216,8 +216,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -227,7 +227,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val rawAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -247,8 +247,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -258,7 +258,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val rawAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -280,8 +280,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash is not valid"
+            actual = exception.message,
+            expected = "Attachment.hash is not valid"
         )
     }
 
@@ -291,7 +291,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir3Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val rawAttachments: MutableList<Fhir3Attachment?> = mutableListOf(
-                null
+            null
         )
 
         every { decryptedRecord.resource } returns resource
@@ -302,8 +302,8 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.upload(any(), any(), any()) wasNot Called }
@@ -316,12 +316,12 @@ class RecordServiceAttachmentUploadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val attachmentKey: GCKey = mockk()
         val rawAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.attachmentsKey } returns attachmentKey
@@ -338,15 +338,15 @@ class RecordServiceAttachmentUploadTest {
         every { SdkAttachmentFactory.wrap(rawAttachments[0]) } returns wrappedAttachment
         every {
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    resource,
-                    updatedAttachments
+                resource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -354,16 +354,16 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedAttachment)
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(resource, updatedAttachments)
         }
@@ -376,13 +376,13 @@ class RecordServiceAttachmentUploadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val attachmentKey: GCKey = mockk()
         val rawAttachments: MutableList<Fhir3Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.attachmentsKey } returns attachmentKey
@@ -399,15 +399,15 @@ class RecordServiceAttachmentUploadTest {
         every { SdkAttachmentFactory.wrap(rawAttachments[1]!!) } returns wrappedAttachment
         every {
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    resource,
-                    updatedAttachments
+                resource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -415,16 +415,16 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedAttachment)
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(resource, updatedAttachments)
         }
@@ -437,12 +437,12 @@ class RecordServiceAttachmentUploadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val attachmentKey: GCKey = mockk()
         val rawAttachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.attachmentsKey } returnsMany listOf(null, attachmentKey)
@@ -461,15 +461,15 @@ class RecordServiceAttachmentUploadTest {
         every { decryptedRecord.attachmentsKey = attachmentKey } returns Unit
         every {
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    resource,
-                    updatedAttachments
+                resource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -477,8 +477,8 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -486,9 +486,9 @@ class RecordServiceAttachmentUploadTest {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey = attachmentKey
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(resource, updatedAttachments)
         }
@@ -509,8 +509,8 @@ class RecordServiceAttachmentUploadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -536,8 +536,8 @@ class RecordServiceAttachmentUploadTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -553,7 +553,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val rawAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -571,8 +571,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.id should be null"
+            actual = exception.message,
+            expected = "Attachment.id should be null"
         )
     }
 
@@ -582,7 +582,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val rawAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -601,8 +601,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -612,7 +612,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val rawAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -632,8 +632,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash and Attachment.size expected"
+            actual = exception.message,
+            expected = "Attachment.hash and Attachment.size expected"
         )
     }
 
@@ -643,7 +643,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val rawAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
 
@@ -665,8 +665,8 @@ class RecordServiceAttachmentUploadTest {
         }
 
         assertEquals(
-                actual = exception.message,
-                expected = "Attachment.hash is not valid"
+            actual = exception.message,
+            expected = "Attachment.hash is not valid"
         )
     }
 
@@ -676,7 +676,7 @@ class RecordServiceAttachmentUploadTest {
         val resource: Fhir4Resource = mockk(relaxed = true)
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val rawAttachments: MutableList<Fhir4Attachment?> = mutableListOf(
-                null
+            null
         )
 
         every { decryptedRecord.resource } returns resource
@@ -687,8 +687,8 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify { attachmentService.upload(any(), any(), any()) wasNot Called }
@@ -701,12 +701,12 @@ class RecordServiceAttachmentUploadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val attachmentKey: GCKey = mockk()
         val rawAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.attachmentsKey } returns attachmentKey
@@ -723,15 +723,15 @@ class RecordServiceAttachmentUploadTest {
         every { SdkAttachmentFactory.wrap(rawAttachments[0]) } returns wrappedAttachment
         every {
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    resource,
-                    updatedAttachments
+                resource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -739,16 +739,16 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedAttachment)
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(resource, updatedAttachments)
         }
@@ -761,13 +761,13 @@ class RecordServiceAttachmentUploadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val attachmentKey: GCKey = mockk()
         val rawAttachments: MutableList<Fhir4Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.attachmentsKey } returns attachmentKey
@@ -784,15 +784,15 @@ class RecordServiceAttachmentUploadTest {
         every { SdkAttachmentFactory.wrap(rawAttachments[1]!!) } returns wrappedAttachment
         every {
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    resource,
-                    updatedAttachments
+                resource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -800,16 +800,16 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
             recordService.getValidHash(wrappedAttachment)
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(resource, updatedAttachments)
         }
@@ -822,12 +822,12 @@ class RecordServiceAttachmentUploadTest {
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val attachmentKey: GCKey = mockk()
         val rawAttachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val wrappedAttachment: WrapperContract.Attachment = spyk()
         val hash = "hash"
         val updatedAttachments = listOf<Pair<WrapperContract.Attachment, List<String>>>(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.attachmentsKey } returnsMany listOf(null, attachmentKey)
@@ -846,15 +846,15 @@ class RecordServiceAttachmentUploadTest {
         every { decryptedRecord.attachmentsKey = attachmentKey } returns Unit
         every {
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
         } returns Single.just(updatedAttachments)
         every {
             recordService.updateFhirResourceIdentifier(
-                    resource,
-                    updatedAttachments
+                resource,
+                updatedAttachments
             )
         } returns Unit
 
@@ -862,8 +862,8 @@ class RecordServiceAttachmentUploadTest {
         val record = recordService.uploadData(decryptedRecord, USER_ID)
         // When
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verifyOrder {
@@ -871,9 +871,9 @@ class RecordServiceAttachmentUploadTest {
             cryptoService.generateGCKey()
             decryptedRecord.attachmentsKey = attachmentKey
             attachmentService.upload(
-                    listOf(wrappedAttachment),
-                    attachmentKey,
-                    USER_ID
+                listOf(wrappedAttachment),
+                attachmentKey,
+                USER_ID
             )
             recordService.updateFhirResourceIdentifier(resource, updatedAttachments)
         }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUtilsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUtilsTest.kt
@@ -136,14 +136,14 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         recordService.checkDataRestrictions(resource)
 
         // Then
         assertTrue(true)
-        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test
@@ -327,14 +327,14 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         recordService.checkDataRestrictions(resource)
 
         // Then
         assertTrue(true)
-        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test
@@ -543,14 +543,14 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val data = recordService.extractUploadData(resource)
 
         // Then
         assertNull(data)
-        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test
@@ -663,14 +663,14 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val data = recordService.extractUploadData(resource)
 
         // Then
         assertNull(data)
-        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test
@@ -806,7 +806,7 @@ class RecordServiceAttachmentUtilsTest {
         every { decryptedRecord.resource } returns resource
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val record = recordService.removeUploadData(decryptedRecord)
@@ -818,7 +818,7 @@ class RecordServiceAttachmentUtilsTest {
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
-        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test
@@ -903,7 +903,7 @@ class RecordServiceAttachmentUtilsTest {
         every { decryptedRecord.resource } returns resource
 
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns mockk()
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val record = recordService.removeUploadData(decryptedRecord)
@@ -915,7 +915,7 @@ class RecordServiceAttachmentUtilsTest {
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
-        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test
@@ -1185,6 +1185,7 @@ class RecordServiceAttachmentUtilsTest {
         every { decryptedRecord.resource = originalResource } just Runs
 
         every { SdkFhirAttachmentHelper.hasAttachment(originalResource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
 
         // When
         val record = recordService.restoreUploadData(
@@ -1201,6 +1202,7 @@ class RecordServiceAttachmentUtilsTest {
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
+        verify { SdkFhirAttachmentHelper.getAttachment(any())!!.wasNot(Called) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUtilsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUtilsTest.kt
@@ -16,14 +16,6 @@
 
 package care.data4life.sdk
 
-
-import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
-import care.data4life.sdk.test.util.GenericTestDataProvider.ATTACHMENT_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.PDF
-import care.data4life.sdk.test.util.GenericTestDataProvider.PDF_OVERSIZED
-import care.data4life.sdk.test.util.GenericTestDataProvider.UNKNOWN
-import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.config.DataRestrictionException
 import care.data4life.sdk.crypto.CryptoContract
@@ -35,6 +27,13 @@ import care.data4life.sdk.fhir.Fhir4Resource
 import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
 import care.data4life.sdk.tag.TaggingContract
+import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
+import care.data4life.sdk.test.util.GenericTestDataProvider.ATTACHMENT_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.PDF
+import care.data4life.sdk.test.util.GenericTestDataProvider.PDF_OVERSIZED
+import care.data4life.sdk.test.util.GenericTestDataProvider.UNKNOWN
+import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.test.util.TestResourceHelper.getJSONResource
 import care.data4life.sdk.util.Base64
 import care.data4life.sdk.wrapper.SdkAttachmentFactory
@@ -76,18 +75,18 @@ class RecordServiceAttachmentUtilsTest {
         clearAllMocks()
 
         recordService = spyk(
-                RecordService(
-                        PARTNER_ID,
-                        ALIAS,
-                        apiService,
-                        tagEncryptionService,
-                        taggingService,
-                        fhirService,
-                        attachmentService,
-                        cryptoService,
-                        errorHandler,
-                        mockk()
-                )
+            RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler,
+                mockk()
+            )
         )
 
         mockkObject(SdkFhirAttachmentHelper)
@@ -111,8 +110,8 @@ class RecordServiceAttachmentUtilsTest {
         val actual = recordService.deleteAttachment(ATTACHMENT_ID, USER_ID).blockingGet()
 
         assertSame(
-                actual = actual,
-                expected = expected
+            actual = actual,
+            expected = expected
         )
 
         verify(exactly = 1) { attachmentService.delete(ATTACHMENT_ID, USER_ID) }
@@ -169,7 +168,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = UNKNOWN
@@ -199,7 +198,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF_OVERSIZED
@@ -229,7 +228,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF
@@ -245,7 +244,7 @@ class RecordServiceAttachmentUtilsTest {
         // When
         recordService.checkDataRestrictions(resource)
 
-        //Then
+        // Then
         assertTrue(true)
 
         unmockkObject(Base64)
@@ -259,8 +258,8 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         val attachments: MutableList<Fhir3Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF
@@ -276,7 +275,7 @@ class RecordServiceAttachmentUtilsTest {
         // When
         recordService.checkDataRestrictions(resource)
 
-        //Then
+        // Then
         assertTrue(true)
 
         verify(exactly = 1) { Base64.decode(any<String>()) }
@@ -292,8 +291,8 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
 
         val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk(),
-                mockk()
+            mockk(),
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF
@@ -313,7 +312,7 @@ class RecordServiceAttachmentUtilsTest {
         // When
         recordService.checkDataRestrictions(resource)
 
-        //Then
+        // Then
         assertTrue(true)
 
         verify(exactly = 1) { Base64.decode(any<String>()) }
@@ -360,7 +359,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         val attachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = UNKNOWN
@@ -390,7 +389,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         val attachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF_OVERSIZED
@@ -420,7 +419,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         val attachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF
@@ -436,7 +435,7 @@ class RecordServiceAttachmentUtilsTest {
         // When
         recordService.checkDataRestrictions(resource)
 
-        //Then
+        // Then
         assertTrue(true)
 
         unmockkObject(Base64)
@@ -450,8 +449,8 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         val attachments: MutableList<Fhir4Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF
@@ -467,7 +466,7 @@ class RecordServiceAttachmentUtilsTest {
         // When
         recordService.checkDataRestrictions(resource)
 
-        //Then
+        // Then
         assertTrue(true)
 
         verify(exactly = 1) { Base64.decode(any<String>()) }
@@ -483,8 +482,8 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
 
         val attachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk(),
-                mockk()
+            mockk(),
+            mockk()
         )
         val encodedPayload = "test"
         val decodedPayload = PDF
@@ -504,7 +503,7 @@ class RecordServiceAttachmentUtilsTest {
         // When
         recordService.checkDataRestrictions(resource)
 
-        //Then
+        // Then
         assertTrue(true)
 
         verify(exactly = 1) { Base64.decode(any<String>()) }
@@ -516,8 +515,8 @@ class RecordServiceAttachmentUtilsTest {
     fun `Given, checkDataRestrictions is called, with a Resource, which has non extractable Attachments, it returns without a failure`() {
         // Given
         val resourceStr = getJSONResource(
-                "fhir4",
-                "s4h-patient-example.patient"
+            "fhir4",
+            "s4h-patient-example.patient"
         )
 
         val doc = SdkFhirParser.toFhir4("Patient", resourceStr)
@@ -573,7 +572,7 @@ class RecordServiceAttachmentUtilsTest {
         // Given
         val resource: Fhir3Resource = mockk()
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val payload = "data"
 
@@ -591,8 +590,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertEquals(
-                actual = data,
-                expected = hashMapOf(attachments[0] to payload)
+            actual = data,
+            expected = hashMapOf(attachments[0] to payload)
         )
     }
 
@@ -601,8 +600,8 @@ class RecordServiceAttachmentUtilsTest {
         // Given
         val resource: Fhir3Resource = mockk()
         val attachments: MutableList<Fhir3Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val payload = "data"
 
@@ -620,8 +619,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertEquals(
-                actual = data,
-                expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
+            actual = data,
+            expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
         )
     }
 
@@ -630,8 +629,8 @@ class RecordServiceAttachmentUtilsTest {
         // Given
         val resource: Fhir3Resource = mockk()
         val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk(),
-                mockk()
+            mockk(),
+            mockk()
         )
         val payload = "data"
 
@@ -652,8 +651,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertEquals(
-                actual = data,
-                expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
+            actual = data,
+            expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
         )
     }
 
@@ -693,7 +692,7 @@ class RecordServiceAttachmentUtilsTest {
         // Given
         val resource: Fhir4Resource = mockk()
         val attachments: MutableList<Any> = mutableListOf(
-                mockk()
+            mockk()
         )
         val payload = "data"
 
@@ -711,8 +710,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertEquals(
-                actual = data,
-                expected = hashMapOf(attachments[0] to payload)
+            actual = data,
+            expected = hashMapOf(attachments[0] to payload)
         )
     }
 
@@ -721,8 +720,8 @@ class RecordServiceAttachmentUtilsTest {
         // Given
         val resource: Fhir4Resource = mockk()
         val attachments: MutableList<Fhir4Attachment?> = mutableListOf(
-                null,
-                mockk()
+            null,
+            mockk()
         )
         val payload = "data"
 
@@ -740,8 +739,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertEquals(
-                actual = data,
-                expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
+            actual = data,
+            expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
         )
     }
 
@@ -750,8 +749,8 @@ class RecordServiceAttachmentUtilsTest {
         // Given
         val resource: Fhir4Resource = mockk()
         val attachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk(),
-                mockk()
+            mockk(),
+            mockk()
         )
         val payload = "data"
 
@@ -772,8 +771,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertEquals(
-                actual = data,
-                expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
+            actual = data,
+            expected = hashMapOf(attachments[1] to payload) as HashMap<Any, String?>
         )
     }
 
@@ -790,8 +789,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -813,8 +812,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -837,8 +836,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -860,8 +859,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -873,7 +872,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir3Resource = mockk()
         val decryptedRecord: DecryptedBaseRecord<Fhir3Resource> = mockk()
         val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.resource } returns resource
@@ -887,8 +886,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { SdkFhirAttachmentHelper.updateAttachmentData(resource, null) }
@@ -910,8 +909,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -934,8 +933,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -957,8 +956,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -970,7 +969,7 @@ class RecordServiceAttachmentUtilsTest {
         val resource: Fhir4Resource = mockk()
         val decryptedRecord: DecryptedBaseRecord<Fhir4Resource> = mockk()
         val attachments: MutableList<Fhir4Attachment> = mutableListOf(
-                mockk()
+            mockk()
         )
 
         every { decryptedRecord.resource } returns resource
@@ -984,8 +983,8 @@ class RecordServiceAttachmentUtilsTest {
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { SdkFhirAttachmentHelper.updateAttachmentData(resource, null) }
@@ -1003,15 +1002,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                attachmentPayload
+            decryptedRecord,
+            originalResource,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -1031,15 +1030,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource as Any,
-                attachmentPayload
+            decryptedRecord,
+            originalResource as Any,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 0) { SdkFhirAttachmentHelper.updateAttachmentData(any(), any()) }
@@ -1060,15 +1059,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                attachmentPayload
+            decryptedRecord,
+            originalResource,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
@@ -1089,15 +1088,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                null
+            decryptedRecord,
+            originalResource,
+            null
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
@@ -1120,15 +1119,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                attachmentPayload
+            decryptedRecord,
+            originalResource,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
@@ -1148,27 +1147,27 @@ class RecordServiceAttachmentUtilsTest {
 
         every { SdkFhirAttachmentHelper.hasAttachment(originalResource) } returns true
         every { SdkFhirAttachmentHelper.getAttachment(originalResource) } returns mutableListOf(
-                mockk()
+            mockk()
         )
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                attachmentPayload
+            decryptedRecord,
+            originalResource,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
         verify(exactly = 1) {
             SdkFhirAttachmentHelper.updateAttachmentData(
-                    originalResource,
-                    attachmentPayload
+                originalResource,
+                attachmentPayload
             )
         }
     }
@@ -1189,15 +1188,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                attachmentPayload
+            decryptedRecord,
+            originalResource,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
@@ -1219,15 +1218,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                null
+            decryptedRecord,
+            originalResource,
+            null
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
@@ -1250,15 +1249,15 @@ class RecordServiceAttachmentUtilsTest {
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                attachmentPayload
+            decryptedRecord,
+            originalResource,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
@@ -1278,27 +1277,27 @@ class RecordServiceAttachmentUtilsTest {
 
         every { SdkFhirAttachmentHelper.hasAttachment(originalResource) } returns true
         every { SdkFhirAttachmentHelper.getAttachment(originalResource) } returns mutableListOf(
-                mockk()
+            mockk()
         )
 
         // When
         val record = recordService.restoreUploadData(
-                decryptedRecord,
-                originalResource,
-                attachmentPayload
+            decryptedRecord,
+            originalResource,
+            attachmentPayload
         )
 
         // Then
         assertSame(
-                actual = record,
-                expected = decryptedRecord
+            actual = record,
+            expected = decryptedRecord
         )
 
         verify(exactly = 1) { decryptedRecord.resource = originalResource }
         verify(exactly = 1) {
             SdkFhirAttachmentHelper.updateAttachmentData(
-                    originalResource,
-                    attachmentPayload
+                originalResource,
+                attachmentPayload
             )
         }
     }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceDownloadAttachmentAndRecordModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceDownloadAttachmentAndRecordModuleTest.kt
@@ -20,6 +20,7 @@ import care.data4life.crypto.GCKey
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.attachment.AttachmentService
 import care.data4life.sdk.attachment.FileService
+import care.data4life.sdk.call.Fhir4Record
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.fhir.Fhir3Identifier
 import care.data4life.sdk.fhir.Fhir4Identifier
@@ -428,7 +429,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
     // Records
     // FHIR 3
     @Test
-    fun `Given, downloadRecord is called with its appropriate parameter, it returns a Fhir3Record`() {
+    fun `Given, downloadFhir3Record is called with its appropriate parameter, it returns a Fhir3Record`() {
         // Given
         val resourceType = "DocumentReference"
         val tags = mapOf(
@@ -490,7 +491,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
         )
 
         // When
-        val result = recordService.downloadRecord<Fhir3DocumentReference>(
+        val result = recordService.downloadFhir3Record<Fhir3DocumentReference>(
             RECORD_ID,
             USER_ID
         ).blockingGet()
@@ -523,5 +524,194 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             actual = result.resource.identifier?.get(1)?.value,
             expected = "d4l_f_p_t#$ATTACHMENT_ID#$PREVIEW_ID#$THUMBNAIL_ID"
         )
+    }
+
+    @Test
+    fun `Given, downloadFhir3Record is called with its appropriate parameter, it fails if the fetched Record is not Fhir3`() {
+        // Given
+        val resourceType = "DocumentReference"
+        val tags = mapOf(
+            "partner" to PARTNER_ID,
+            "client" to CLIENT_ID,
+            "fhirversion" to "4.0.1",
+            "resourcetype" to resourceType
+        )
+
+        val rawAttachment = TestResourceHelper.getByteResource("attachments", "sample.pdf")
+        val attachment = Base64.encodeToString(String(rawAttachment))
+
+        val template = TestResourceHelper.loadTemplateWithAttachments(
+            "common",
+            "documentReference-with-attachment-template",
+            RECORD_ID,
+            PARTNER_ID,
+            "Sample PDF",
+            "application/pdf",
+            attachment
+        )
+
+        val internalResource = SdkFhirParser.toFhir4(
+            resourceType,
+            template
+        ) as Fhir4DocumentReference
+
+        runAttachmentDownloadFlow(
+            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            rawAttachment = rawAttachment,
+            tags = tags,
+            attachmentId = ATTACHMENT_ID
+        )
+
+        // When
+        assertFailsWith<IllegalArgumentException> {
+            recordService.downloadFhir3Record<Fhir3DocumentReference>(
+                RECORD_ID,
+                USER_ID
+            ).blockingGet()
+        }
+    }
+
+    // FHIR 4
+    @Test
+    fun `Given, downloadFhir4Record is called with its appropriate parameter, it returns a Fhir4Record`() {
+        // Given
+        val resourceType = "DocumentReference"
+        val tags = mapOf(
+            "partner" to PARTNER_ID,
+            "client" to CLIENT_ID,
+            "fhirversion" to "4.0.1",
+            "resourcetype" to resourceType
+        )
+
+        val rawAttachment = TestResourceHelper.getByteResource("attachments", "sample.pdf")
+        val attachment = Base64.encodeToString(String(rawAttachment))
+
+        val template = TestResourceHelper.loadTemplateWithAttachments(
+            "common",
+            "documentReference-with-attachment-template",
+            RECORD_ID,
+            PARTNER_ID,
+            "Sample PDF",
+            "application/pdf",
+            attachment
+        )
+
+        val resource = SdkFhirParser.toFhir4(
+            resourceType,
+            template
+        ) as Fhir4DocumentReference
+
+        val internalResource = SdkFhirParser.toFhir4(
+            resourceType,
+            template
+        ) as Fhir4DocumentReference
+
+        resource.identifier!!.add(
+            Fhir4Identifier().also {
+                it.assigner = Fhir4Reference().also { ref -> ref.reference = PARTNER_ID }
+                it.value = "d4l_f_p_t#$ATTACHMENT_ID#$PREVIEW_ID#$THUMBNAIL_ID"
+            }
+        )
+
+        resource.content[0].attachment.id = ATTACHMENT_ID
+        resource.content[0].attachment.hash = Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
+
+        internalResource.identifier!!.add(
+            Fhir4Identifier().also {
+                it.assigner = Fhir4Reference().also { ref -> ref.reference = PARTNER_ID }
+                it.value = "d4l_f_p_t#$ATTACHMENT_ID#$PREVIEW_ID#$THUMBNAIL_ID"
+            }
+        )
+
+        internalResource.content[0].attachment.id = ATTACHMENT_ID
+        internalResource.content[0].attachment.data = null
+        internalResource.content[0].attachment.hash = Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
+
+        runAttachmentDownloadFlow(
+            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            rawAttachment = rawAttachment,
+            tags = tags,
+            attachmentId = ATTACHMENT_ID
+        )
+
+        // When
+        val result = recordService.downloadFhir4Record<Fhir4DocumentReference>(
+            RECORD_ID,
+            USER_ID
+        ).blockingGet()
+
+        // Then
+        assertTrue(result is Fhir4Record)
+        assertTrue(result.resource.identifier!!.isNotEmpty())
+        assertEquals(
+            expected = flowHelper.buildMeta(CREATION_DATE, UPDATE_DATE),
+            actual = result.meta
+        )
+
+        assertEquals(
+            expected = SdkFhirParser.fromResource(resource),
+            actual = SdkFhirParser.fromResource(result.resource)
+        )
+        assertEquals(
+            actual = result.resource.content.size,
+            expected = 1
+        )
+        assertEquals(
+            actual = result.resource.content[0].attachment.data,
+            expected = attachment
+        )
+        assertEquals(
+            actual = result.resource.content[0].attachment.id,
+            expected = ATTACHMENT_ID
+        )
+        assertEquals(
+            actual = result.resource.identifier?.get(1)?.value,
+            expected = "d4l_f_p_t#$ATTACHMENT_ID#$PREVIEW_ID#$THUMBNAIL_ID"
+        )
+    }
+
+    @Test
+    fun `Given, downloadFhir4Record is called with its appropriate parameter, it fails if the fetched Record is not Fhir4`() {
+        // Given
+        val resourceType = "DocumentReference"
+        val tags = mapOf(
+            "partner" to PARTNER_ID,
+            "client" to CLIENT_ID,
+            "fhirversion" to "3.0.1",
+            "resourcetype" to resourceType
+        )
+
+        val rawAttachment = TestResourceHelper.getByteResource("attachments", "sample.pdf")
+        val attachment = Base64.encodeToString(String(rawAttachment))
+
+        val template = TestResourceHelper.loadTemplateWithAttachments(
+            "common",
+            "documentReference-with-attachment-template",
+            RECORD_ID,
+            PARTNER_ID,
+            "Sample PDF",
+            "application/pdf",
+            attachment
+        )
+
+        val internalResource = SdkFhirParser.toFhir3(
+            resourceType,
+            template
+        ) as Fhir3DocumentReference
+
+        runAttachmentDownloadFlow(
+            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            rawAttachment = rawAttachment,
+            tags = tags,
+            attachmentId = ATTACHMENT_ID
+        )
+
+        // When
+        assertFailsWith<IllegalArgumentException> {
+            recordService.downloadFhir4Record<Fhir4DocumentReference>(
+                RECORD_ID,
+                USER_ID
+            ).blockingGet()
+        }
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
@@ -16,17 +16,14 @@
 package care.data4life.sdk
 
 import care.data4life.crypto.GCKey
-import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
-import care.data4life.sdk.test.util.GenericTestDataProvider.ATTACHMENT_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.attachment.ThumbnailService.Companion.SPLIT_CHAR
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.fhir.Fhir3Attachment
 import care.data4life.sdk.fhir.Fhir3Identifier
 import care.data4life.sdk.fhir.Fhir3Resource
+import care.data4life.sdk.fhir.Fhir4Attachment
+import care.data4life.sdk.fhir.Fhir4Identifier
 import care.data4life.sdk.fhir.Fhir4Resource
 import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.DataValidationException
@@ -36,8 +33,14 @@ import care.data4life.sdk.model.RecordMapper
 import care.data4life.sdk.network.model.EncryptedRecord
 import care.data4life.sdk.network.model.definitions.DecryptedBaseRecord
 import care.data4life.sdk.network.model.definitions.DecryptedFhir3Record
+import care.data4life.sdk.network.model.definitions.DecryptedFhir4Record
 import care.data4life.sdk.record.RecordContract
 import care.data4life.sdk.tag.TaggingContract
+import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
+import care.data4life.sdk.test.util.GenericTestDataProvider.ATTACHMENT_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.wrapper.SdkAttachmentFactory
 import care.data4life.sdk.wrapper.SdkFhirAttachmentHelper
 import care.data4life.sdk.wrapper.WrapperContract
@@ -76,18 +79,18 @@ class RecordServiceTest {
         clearAllMocks()
 
         recordService = spyk(
-                RecordService(
-                        PARTNER_ID,
-                        ALIAS,
-                        apiService,
-                        tagEncryptionService,
-                        taggingService,
-                        fhirService,
-                        attachmentService,
-                        cryptoService,
-                        errorHandler,
-                        mockk()
-                )
+            RecordService(
+                PARTNER_ID,
+                ALIAS,
+                apiService,
+                tagEncryptionService,
+                taggingService,
+                fhirService,
+                attachmentService,
+                cryptoService,
+                errorHandler,
+                mockk()
+            )
         )
     }
 
@@ -109,8 +112,8 @@ class RecordServiceTest {
 
         //
         assertEquals(
-                actual = hash,
-                expected = "qUqP5cyxm6YcTAhz05Hph5gvu9M="
+            actual = hash,
+            expected = "qUqP5cyxm6YcTAhz05Hph5gvu9M="
         )
     }
 
@@ -142,23 +145,23 @@ class RecordServiceTest {
 
         every {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something",
+                PARTNER_ID
             )
         } returns mockk()
 
         // When
         recordService.updateFhirResourceIdentifier(
-                resource,
-                listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to listOf())
+            resource,
+            listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to listOf())
         )
 
         verify(exactly = 1) {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something",
+                PARTNER_ID
             )
         }
 
@@ -172,31 +175,31 @@ class RecordServiceTest {
         val attachment = mockk<WrapperContract.Attachment>()
         val resource = mockk<Fhir3Resource>(relaxed = true)
         val amendments = listOf(
-                "tomato",
-                "soup"
+            "tomato",
+            "soup"
         )
 
         every { attachment.id } returns "something"
 
         every {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something#tomato#soup",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something#tomato#soup",
+                PARTNER_ID
             )
         } returns mockk()
 
         // When
         recordService.updateFhirResourceIdentifier(
-                resource,
-                listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
+            resource,
+            listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
         )
 
         verify(exactly = 1) {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something#tomato#soup",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something#tomato#soup",
+                PARTNER_ID
             )
         }
 
@@ -215,15 +218,15 @@ class RecordServiceTest {
 
         // When
         recordService.updateFhirResourceIdentifier(
-                resource,
-                listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
+            resource,
+            listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
         )
 
         verify(exactly = 0) {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    any(),
-                    PARTNER_ID
+                resource,
+                any(),
+                PARTNER_ID
             )
         }
 
@@ -241,23 +244,23 @@ class RecordServiceTest {
 
         every {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something",
+                PARTNER_ID
             )
         } returns mockk()
 
         // When
         recordService.updateFhirResourceIdentifier(
-                resource,
-                listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to listOf())
+            resource,
+            listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to listOf())
         )
 
         verify(exactly = 1) {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something",
+                PARTNER_ID
             )
         }
 
@@ -271,31 +274,31 @@ class RecordServiceTest {
         val attachment = mockk<WrapperContract.Attachment>()
         val resource = mockk<Fhir4Resource>(relaxed = true)
         val amendments = listOf(
-                "tomato",
-                "soup"
+            "tomato",
+            "soup"
         )
 
         every { attachment.id } returns "something"
 
         every {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something#tomato#soup",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something#tomato#soup",
+                PARTNER_ID
             )
         } returns mockk()
 
         // When
         recordService.updateFhirResourceIdentifier(
-                resource,
-                listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
+            resource,
+            listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
         )
 
         verify(exactly = 1) {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    "d4l_f_p_t#something#tomato#soup",
-                    PARTNER_ID
+                resource,
+                "d4l_f_p_t#something#tomato#soup",
+                PARTNER_ID
             )
         }
 
@@ -314,15 +317,15 @@ class RecordServiceTest {
 
         // When
         recordService.updateFhirResourceIdentifier(
-                resource,
-                listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
+            resource,
+            listOf<Pair<WrapperContract.Attachment, List<String>?>>(attachment to amendments)
         )
 
         verify(exactly = 0) {
             SdkFhirAttachmentHelper.appendIdentifier(
-                    resource,
-                    any(),
-                    PARTNER_ID
+                resource,
+                any(),
+                PARTNER_ID
             )
         }
 
@@ -341,8 +344,8 @@ class RecordServiceTest {
 
         // Then
         assertSame(
-                actual = actual,
-                expected = expected
+            actual = actual,
+            expected = expected
         )
 
         verify(exactly = 1) { apiService.deleteRecord(ALIAS, RECORD_ID, USER_ID) }
@@ -353,35 +356,898 @@ class RecordServiceTest {
         // Given
         val expected: Completable = Completable.complete()
         val ids = listOf(
-                "1",
-                "2"
+            "1",
+            "2"
         )
 
         every { apiService.deleteRecord(ALIAS, or(ids[0], ids[1]), USER_ID) } returns expected
 
         // When
         val subscriber = recordService.deleteRecords(userId = USER_ID, recordIds = ids)
-                .test()
-                .await()
+            .test()
+            .await()
 
         // Then
         val actual = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
+            .assertNoErrors()
+            .assertComplete()
+            .assertValueCount(1)
+            .values()[0]
 
         assertEquals(
-                actual = actual.successfulDeletes,
-                expected = ids
+            actual = actual.successfulDeletes,
+            expected = ids
         )
 
         assertEquals(
-                actual = actual.failedDeletes,
-                expected = listOf()
+            actual = actual.failedDeletes,
+            expected = listOf()
         )
 
         verify(exactly = 2) { apiService.deleteRecord(ALIAS, or(ids[0], ids[1]), USER_ID) }
+    }
+
+    @Test
+    fun `Given, deleteAttachment is called, with an AttachmentId and a UserId, it delegates it to the AttachmentService and returns its result`() {
+        // Given
+        val expected: Single<Boolean> = mockk()
+
+        every { attachmentService.delete(ATTACHMENT_ID, USER_ID) } returns expected
+        // When
+        val actual = recordService.deleteAttachment(ATTACHMENT_ID, USER_ID)
+
+        // Then
+        assertSame(
+            actual = actual,
+            expected = expected
+        )
+    }
+
+    // FHIR3 - downloadAttachmentsFromStorage
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it fails, if it not capable of having Attachments`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = mockk()
+        val resource: Fhir3Resource = mockk()
+        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
+
+        // Then
+        val error = assertFailsWith<IllegalArgumentException> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Expected a record of a type that has attachment"
+        )
+
+        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it fails, if there are no actual Attachments`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val resource: Fhir3Resource = mockk()
+        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns null
+
+        // Then
+        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Please provide correct attachment ids!"
+        )
+
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it fails, if the AttachmentIDs does not match the attachments of the record`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
+            mockk(relaxed = true)
+        )
+        val resource: Fhir3Resource = mockk()
+        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+
+        // Then
+        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Please provide correct attachment ids!"
+        )
+
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it fails, while filter the Attachments by their id`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
+            mockk(),
+            mockk()
+        )
+        val resource: Fhir3Resource = mockk()
+        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+
+        every { wrappedAttachments[0].id } returns attachmentIds[0]
+        every { wrappedAttachments[1].id } returns attachmentIds[1]
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+
+        // Then
+        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Please provide correct attachment ids!"
+        )
+
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it downloads the requested Attachments`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        mockkObject(SdkAttachmentFactory)
+        // Given
+        val attachmentKey: GCKey = mockk()
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
+            mockk(),
+            mockk()
+        )
+        val resource: Fhir3Resource = mockk()
+        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
+        val identifiers: List<Fhir3Identifier> = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedAttachments: List<Fhir3Attachment> = listOf(
+            spyk(),
+            spyk()
+        )
+
+        every { wrappedAttachments[0].id } returns attachmentIds[0]
+        every { wrappedAttachments[1].id } returns attachmentIds[1]
+
+        every { decryptedRecord.resource } returns resource
+        every { decryptedRecord.attachmentsKey } returns attachmentKey
+
+        every { downloadedWrappedAttachments[0].unwrap<Fhir3Attachment>() } returns downloadedAttachments[0]
+        every { downloadedWrappedAttachments[1].unwrap<Fhir3Attachment>() } returns downloadedAttachments[1]
+
+        every { downloadedWrappedAttachments[0].id } returns "abc"
+        every { downloadedWrappedAttachments[1].id } returns "cdf"
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+        every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
+        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
+        every {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+        } just Runs
+
+        every {
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(downloadedWrappedAttachments)
+
+        // When
+        val subscriber = recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full,
+            decryptedRecord
+        ).test().await()
+
+        // Then
+        val result = subscriber
+            .assertNoErrors()
+            .assertComplete()
+            .values()[0]
+
+        assertEquals(
+            actual = result.size,
+            expected = 2
+        )
+        assertEquals(
+            actual = result,
+            expected = downloadedAttachments
+        )
+
+        verifyOrder {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+        }
+        verify { recordService.updateAttachmentMeta(any()) wasNot Called }
+
+        unmockkObject(SdkFhirAttachmentHelper)
+        unmockkObject(SdkAttachmentFactory)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it downloads the requested Attachments, while updating their metas`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        mockkObject(SdkAttachmentFactory)
+        // Given
+        val attachmentKey: GCKey = mockk()
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
+            mockk(),
+            mockk()
+        )
+        val resource: Fhir3Resource = mockk()
+        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
+        val identifiers: List<Fhir3Identifier> = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedAttachments: List<Fhir3Attachment> = listOf(
+            spyk(),
+            spyk()
+        )
+        val downloadedAttachmentsIds = listOf(
+            "tomato${SPLIT_CHAR}soup",
+            "potato${SPLIT_CHAR}soup"
+        )
+
+        every { wrappedAttachments[0].id } returns attachmentIds[0]
+        every { wrappedAttachments[1].id } returns attachmentIds[1]
+
+        every { decryptedRecord.resource } returns resource
+        every { decryptedRecord.attachmentsKey } returns attachmentKey
+
+        every { downloadedWrappedAttachments[0].unwrap<Fhir3Attachment>() } returns downloadedAttachments[0]
+        every { downloadedWrappedAttachments[1].unwrap<Fhir3Attachment>() } returns downloadedAttachments[1]
+
+        every { downloadedWrappedAttachments[0].id } returns downloadedAttachmentsIds[0]
+        every { downloadedWrappedAttachments[1].id } returns downloadedAttachmentsIds[1]
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+        every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
+        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
+        every {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+        } just Runs
+
+        every {
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(downloadedWrappedAttachments)
+
+        every {
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[0])
+        } returns downloadedWrappedAttachments[0]
+
+        every {
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[1])
+        } returns downloadedWrappedAttachments[1]
+
+        // When
+        val subscriber = recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full,
+            decryptedRecord
+        ).test().await()
+
+        // Then
+        val result = subscriber
+            .assertNoErrors()
+            .assertComplete()
+            .values()[0]
+
+        assertEquals(
+            actual = result.size,
+            expected = 2
+        )
+        assertEquals(
+            actual = result,
+            expected = downloadedAttachments
+        )
+
+        verifyOrder {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[0])
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[1])
+        }
+
+        unmockkObject(SdkFhirAttachmentHelper)
+        unmockkObject(SdkAttachmentFactory)
+    }
+
+    // FHIR4 - downloadAttachmentsFromStorage
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir4Resource, it fails, if it not capable of having Attachments`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = mockk()
+        val resource: Fhir4Resource = mockk()
+        val decryptedRecord: DecryptedFhir4Record<Fhir4Resource> = mockk()
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
+        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
+
+        // Then
+        val error = assertFailsWith<IllegalArgumentException> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir4Resource, Fhir4Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Expected a record of a type that has attachment"
+        )
+
+        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir4Resource, it fails, if there are no actual Attachments`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val resource: Fhir4Resource = mockk()
+        val decryptedRecord: DecryptedFhir4Record<Fhir4Resource> = mockk()
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns null
+
+        // Then
+        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir4Resource, Fhir4Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Please provide correct attachment ids!"
+        )
+
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir4Resource, it fails, if the AttachmentIDs does not match the attachments of the record`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir4Attachment> = mutableListOf(
+            mockk(relaxed = true)
+        )
+        val resource: Fhir4Resource = mockk()
+        val decryptedRecord: DecryptedFhir4Record<Fhir4Resource> = mockk()
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+
+        // Then
+        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir4Resource, Fhir4Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Please provide correct attachment ids!"
+        )
+
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir4Resource, it fails, while filter the Attachments by their id`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        // Given
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir4Attachment> = mutableListOf(
+            mockk(),
+            mockk()
+        )
+        val resource: Fhir4Resource = mockk()
+        val decryptedRecord: DecryptedFhir4Record<Fhir4Resource> = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+
+        every { wrappedAttachments[0].id } returns attachmentIds[0]
+        every { wrappedAttachments[1].id } returns attachmentIds[1]
+
+        every { decryptedRecord.resource } returns resource
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+
+        // Then
+        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
+            // When
+            recordService.downloadAttachmentsFromStorage<Fhir4Resource, Fhir4Attachment>(
+                attachmentIds,
+                USER_ID,
+                DownloadType.Full,
+                decryptedRecord
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Please provide correct attachment ids!"
+        )
+
+        unmockkObject(SdkFhirAttachmentHelper)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir4Resource, it downloads the requested Attachments`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        mockkObject(SdkAttachmentFactory)
+        // Given
+        val attachmentKey: GCKey = mockk()
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir4Attachment> = mutableListOf(
+            mockk(),
+            mockk()
+        )
+        val resource: Fhir4Resource = mockk()
+        val decryptedRecord: DecryptedFhir4Record<Fhir4Resource> = mockk()
+        val identifiers: List<Fhir4Identifier> = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedAttachments: List<Fhir4Attachment> = listOf(
+            spyk(),
+            spyk()
+        )
+
+        every { wrappedAttachments[0].id } returns attachmentIds[0]
+        every { wrappedAttachments[1].id } returns attachmentIds[1]
+
+        every { decryptedRecord.resource } returns resource
+        every { decryptedRecord.attachmentsKey } returns attachmentKey
+
+        every { downloadedWrappedAttachments[0].unwrap<Fhir4Attachment>() } returns downloadedAttachments[0]
+        every { downloadedWrappedAttachments[1].unwrap<Fhir4Attachment>() } returns downloadedAttachments[1]
+
+        every { downloadedWrappedAttachments[0].id } returns "abc"
+        every { downloadedWrappedAttachments[1].id } returns "cdf"
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+        every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
+        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
+        every {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+        } just Runs
+
+        every {
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(downloadedWrappedAttachments)
+
+        // When
+        val subscriber = recordService.downloadAttachmentsFromStorage<Fhir4Resource, Fhir4Attachment>(
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full,
+            decryptedRecord
+        ).test().await()
+
+        // Then
+        val result = subscriber
+            .assertNoErrors()
+            .assertComplete()
+            .values()[0]
+
+        assertEquals(
+            actual = result.size,
+            expected = 2
+        )
+        assertEquals(
+            actual = result,
+            expected = downloadedAttachments
+        )
+
+        verifyOrder {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+        }
+        verify { recordService.updateAttachmentMeta(any()) wasNot Called }
+
+        unmockkObject(SdkFhirAttachmentHelper)
+        unmockkObject(SdkAttachmentFactory)
+    }
+
+    @Test
+    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir4Resource, it downloads the requested Attachments, while updating their metas`() {
+        mockkObject(SdkFhirAttachmentHelper)
+        mockkObject(SdkAttachmentFactory)
+        // Given
+        val attachmentKey: GCKey = mockk()
+        val attachmentIds: List<String> = listOf(
+            "abc",
+            "bcd"
+        )
+        val attachments: MutableList<Fhir4Attachment> = mutableListOf(
+            mockk(),
+            mockk()
+        )
+        val resource: Fhir4Resource = mockk()
+        val decryptedRecord: DecryptedFhir4Record<Fhir4Resource> = mockk()
+        val identifiers: List<Fhir4Identifier> = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
+            mockk(),
+            mockk()
+        )
+        val downloadedAttachments: List<Fhir4Attachment> = listOf(
+            spyk(),
+            spyk()
+        )
+        val downloadedAttachmentsIds = listOf(
+            "tomato${SPLIT_CHAR}soup",
+            "potato${SPLIT_CHAR}soup"
+        )
+
+        every { wrappedAttachments[0].id } returns attachmentIds[0]
+        every { wrappedAttachments[1].id } returns attachmentIds[1]
+
+        every { decryptedRecord.resource } returns resource
+        every { decryptedRecord.attachmentsKey } returns attachmentKey
+
+        every { downloadedWrappedAttachments[0].unwrap<Fhir4Attachment>() } returns downloadedAttachments[0]
+        every { downloadedWrappedAttachments[1].unwrap<Fhir4Attachment>() } returns downloadedAttachments[1]
+
+        every { downloadedWrappedAttachments[0].id } returns downloadedAttachmentsIds[0]
+        every { downloadedWrappedAttachments[1].id } returns downloadedAttachmentsIds[1]
+
+        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
+        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
+        every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
+        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
+        every {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+        } just Runs
+
+        every {
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+        } returns Single.just(downloadedWrappedAttachments)
+
+        every {
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[0])
+        } returns downloadedWrappedAttachments[0]
+
+        every {
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[1])
+        } returns downloadedWrappedAttachments[1]
+
+        // When
+        val subscriber = recordService.downloadAttachmentsFromStorage<Fhir4Resource, Fhir4Attachment>(
+            attachmentIds,
+            USER_ID,
+            DownloadType.Full,
+            decryptedRecord
+        ).test().await()
+
+        // Then
+        val result = subscriber
+            .assertNoErrors()
+            .assertComplete()
+            .values()[0]
+
+        assertEquals(
+            actual = result.size,
+            expected = 2
+        )
+        assertEquals(
+            actual = result,
+            expected = downloadedAttachments
+        )
+
+        verifyOrder {
+            recordService.setAttachmentIdForDownloadType(
+                wrappedAttachments,
+                identifiers,
+                DownloadType.Full
+            )
+            attachmentService.download(
+                wrappedAttachments,
+                attachmentKey,
+                USER_ID
+            )
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[0])
+            recordService.updateAttachmentMeta(downloadedWrappedAttachments[1])
+        }
+
+        unmockkObject(SdkFhirAttachmentHelper)
+        unmockkObject(SdkAttachmentFactory)
+    }
+
+    @Test
+    fun `Given, downloadAttachment is called, with it  a RecordId, AttachmentIds, UserId and a DownloadType, it delegates the call to downloadAttachments and returns its result`() {
+        // Given
+        val attachmentId = "abc"
+        val expected: Fhir3Attachment = mockk()
+
+        every {
+            recordService.downloadAttachments(
+                RECORD_ID,
+                listOf(attachmentId),
+                USER_ID,
+                DownloadType.Full
+            )
+        } returns Single.just(listOf(expected))
+
+        // When
+        val subscriber = recordService.downloadAttachment(
+            RECORD_ID,
+            attachmentId,
+            USER_ID,
+            DownloadType.Full
+        ).test().await()
+
+        // Then
+        val result = subscriber
+            .assertNoErrors()
+            .assertComplete()
+            .values()[0]
+
+        assertSame(
+            actual = result,
+            expected = expected
+        )
+
+        verifyOrder {
+            recordService.downloadAttachments(
+                RECORD_ID,
+                listOf(attachmentId),
+                USER_ID,
+                DownloadType.Full
+            )
+        }
+    }
+
+    @Test
+    fun `Given, downloadAttachments is called with a RecordId, AttachmentIds, UserId and a DownloadType, returns encountered Attachments`() {
+        // Given
+        val userId = "asd"
+        val recordId = "ads"
+        val attachmentId = "lllll"
+        val attachmentIds = listOf(attachmentId)
+        val type = DownloadType.Medium
+
+        val response1 = mockk<Fhir3Attachment>()
+        val response2 = mockk<Fhir3Attachment>()
+        val response = listOf(response1, response2)
+
+        val encryptedRecord = mockk<EncryptedRecord>()
+        val decryptedRecord = mockk<DecryptedFhir3Record<Fhir3Resource>>()
+
+        every { apiService.fetchRecord(ALIAS, userId, recordId) } returns Single.just(encryptedRecord)
+        every { recordService.decryptRecord<Any>(encryptedRecord, userId) } returns decryptedRecord as DecryptedBaseRecord<Any>
+        every {
+            recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+                attachmentIds,
+                userId,
+                type,
+                decryptedRecord
+            )
+        } returns Single.just(response)
+
+        // When
+        val subscriber = recordService.downloadAttachments(
+            recordId,
+            attachmentIds,
+            userId,
+            type
+        ).test().await()
+
+        // Then
+        val result = subscriber
+            .assertNoErrors()
+            .assertComplete()
+            .assertValueCount(1)
+            .values()[0]
+
+        assertSame(
+            response,
+            result
+        )
+
+        verifyOrder {
+            apiService.fetchRecord(ALIAS, userId, recordId)
+            recordService.decryptRecord<Any>(encryptedRecord, userId)
+            recordService.downloadAttachmentsFromStorage<Fhir3Resource, Fhir3Attachment>(
+                attachmentIds,
+                userId,
+                type,
+                decryptedRecord
+            )
+        }
     }
 
     @Test
@@ -411,14 +1277,14 @@ class RecordServiceTest {
 
         // Then
         val record = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
+            .assertNoErrors()
+            .assertComplete()
+            .assertValueCount(1)
+            .values()[0]
 
         assertSame(
-                actual = record,
-                expected = createdRecord
+            actual = record,
+            expected = createdRecord
         )
 
         verifyOrder {
@@ -437,13 +1303,13 @@ class RecordServiceTest {
     fun `Given, downloadRecords is called with RecordIds and UserIds, it streams them into downloadRecord and returns the results`() {
         // Given
         val recordIds = listOf(
-                "1",
-                "2"
+            "1",
+            "2"
         )
 
         val records: List<Record<Fhir3Resource>> = listOf(
-                mockk(),
-                mockk()
+            mockk(),
+            mockk()
         )
 
         every {
@@ -455,471 +1321,19 @@ class RecordServiceTest {
 
         // Then
         val actual = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
+            .assertNoErrors()
+            .assertComplete()
+            .assertValueCount(1)
+            .values()[0]
 
         assertEquals(
-                actual = actual.successfulDownloads,
-                expected = records
+            actual = actual.successfulDownloads,
+            expected = records
         )
 
         assertEquals(
-                actual = actual.failedDownloads,
-                expected = listOf()
+            actual = actual.failedDownloads,
+            expected = listOf()
         )
-    }
-
-    @Test
-    fun `Given, deleteAttachment is called, with an AttachmentId and a UserId, it delegates it to the AttachmentService and returns its result`() {
-        // Given
-        val expected: Single<Boolean> = mockk()
-
-        every { attachmentService.delete(ATTACHMENT_ID, USER_ID) } returns expected
-        // When
-        val actual = recordService.deleteAttachment(ATTACHMENT_ID, USER_ID)
-
-        // Then
-        assertSame(
-                actual = actual,
-                expected = expected
-        )
-    }
-
-    @Test
-    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it fails, if it not capable of having Attachments`() {
-        mockkObject(SdkFhirAttachmentHelper)
-        // Given
-        val attachmentIds: List<String> = mockk()
-        val resource: Fhir3Resource = mockk()
-        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
-
-        every { decryptedRecord.resource } returns resource
-
-        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns false
-        every { SdkFhirAttachmentHelper.getAttachment(any()) } returns mockk()
-
-        // Then
-        val error = assertFailsWith<IllegalArgumentException> {
-            // When
-            recordService.downloadAttachmentsFromStorage(
-                    attachmentIds,
-                    USER_ID,
-                    DownloadType.Full,
-                    decryptedRecord
-            )
-        }
-
-        assertEquals(
-                actual = error.message,
-                expected = "Expected a record of a type that has attachment"
-        )
-
-        verify { SdkFhirAttachmentHelper.getAttachment(resource)!!.wasNot(Called) }
-        unmockkObject(SdkFhirAttachmentHelper)
-    }
-
-    @Test
-    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it fails, if the AttachmentIDs does not match the attachments of the record`() {
-        mockkObject(SdkFhirAttachmentHelper)
-        // Given
-        val attachmentIds: List<String> = listOf(
-                "abc",
-                "bcd"
-        )
-        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                mockk(relaxed = true)
-        )
-        val resource: Fhir3Resource = mockk()
-        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
-
-        every { decryptedRecord.resource } returns resource
-
-        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
-
-        // Then
-        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
-            // When
-            recordService.downloadAttachmentsFromStorage(
-                    attachmentIds,
-                    USER_ID,
-                    DownloadType.Full,
-                    decryptedRecord
-            )
-        }
-
-        assertEquals(
-                actual = error.message,
-                expected = "Please provide correct attachment ids!"
-        )
-
-        unmockkObject(SdkFhirAttachmentHelper)
-    }
-
-    @Test
-    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, which contains a Fhir3Resource, it fails, while filter the Attachments by their id`() {
-        mockkObject(SdkFhirAttachmentHelper)
-        // Given
-        val attachmentIds: List<String> = listOf(
-                "abc",
-                "bcd"
-        )
-        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                spyk(),
-                spyk()
-        )
-        val resource: Fhir3Resource = mockk()
-        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
-
-        attachments[0].id = attachmentIds[0]
-        attachments[1].id = "efg"
-
-        every { decryptedRecord.resource } returns resource
-
-        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
-
-        // Then
-        val error = assertFailsWith<DataValidationException.IdUsageViolation> {
-            // When
-            recordService.downloadAttachmentsFromStorage(
-                    attachmentIds,
-                    USER_ID,
-                    DownloadType.Full,
-                    decryptedRecord
-            )
-        }
-
-        assertEquals(
-                actual = error.message,
-                expected = "Please provide correct attachment ids!"
-        )
-
-        unmockkObject(SdkFhirAttachmentHelper)
-    }
-
-    @Test
-    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, it downloads the requested Attachments`() {
-        mockkObject(SdkFhirAttachmentHelper)
-        mockkObject(SdkAttachmentFactory)
-        // Given
-        val attachmentKey: GCKey = mockk()
-        val attachmentIds: List<String> = listOf(
-                "abc",
-                "bcd"
-        )
-        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                spyk(),
-                spyk()
-        )
-        val resource: Fhir3Resource = mockk()
-        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
-        val identifiers: List<Fhir3Identifier> = mockk()
-        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
-                mockk(),
-                mockk()
-        )
-        val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
-                mockk(),
-                mockk()
-        )
-        val downloadedAttachments: List<Fhir3Attachment> = listOf(
-                spyk(),
-                spyk()
-        )
-
-        attachments[0].id = attachmentIds[0]
-        attachments[1].id = attachmentIds[0]
-
-        every { decryptedRecord.resource } returns resource
-        every { decryptedRecord.attachmentsKey } returns attachmentKey
-
-        every { downloadedWrappedAttachments[0].unwrap<Fhir3Attachment>() } returns downloadedAttachments[0]
-        every { downloadedWrappedAttachments[1].unwrap<Fhir3Attachment>() } returns downloadedAttachments[1]
-
-        every { downloadedWrappedAttachments[0].id } returns "abc"
-        every { downloadedWrappedAttachments[1].id } returns "cdf"
-
-        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
-        every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
-        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
-        every {
-            recordService.setAttachmentIdForDownloadType(
-                    wrappedAttachments,
-                    identifiers,
-                    DownloadType.Full
-            )
-        } just Runs
-
-        every {
-            attachmentService.download(
-                    wrappedAttachments,
-                    attachmentKey,
-                    USER_ID
-            )
-        } returns Single.just(downloadedWrappedAttachments)
-
-        // When
-        val subscriber = recordService.downloadAttachmentsFromStorage(
-                attachmentIds,
-                USER_ID,
-                DownloadType.Full,
-                decryptedRecord
-        ).test().await()
-
-        // Then
-        val result = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .values()[0]
-
-        assertEquals(
-                actual = result.size,
-                expected = 2
-        )
-        assertEquals(
-                actual = result,
-                expected = downloadedAttachments
-        )
-
-        verifyOrder {
-            recordService.setAttachmentIdForDownloadType(
-                    wrappedAttachments,
-                    identifiers,
-                    DownloadType.Full
-            )
-            attachmentService.download(
-                    wrappedAttachments,
-                    attachmentKey,
-                    USER_ID
-            )
-        }
-        verify { recordService.updateAttachmentMeta(any()) wasNot Called }
-
-        unmockkObject(SdkFhirAttachmentHelper)
-        unmockkObject(SdkAttachmentFactory)
-    }
-
-    @Test
-    fun `Given, downloadAttachmentsFromStorage is called, with a list of AttachmentsIds, a DecryptedRecord, it downloads the requested Attachments, while updating their metas`() {
-        mockkObject(SdkFhirAttachmentHelper)
-        mockkObject(SdkAttachmentFactory)
-        // Given
-        val attachmentKey: GCKey = mockk()
-        val attachmentIds: List<String> = listOf(
-                "abc",
-                "bcd"
-        )
-        val attachments: MutableList<Fhir3Attachment> = mutableListOf(
-                spyk(),
-                spyk()
-        )
-        val resource: Fhir3Resource = mockk()
-        val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
-        val identifiers: List<Fhir3Identifier> = mockk()
-        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
-                mockk(),
-                mockk()
-        )
-        val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
-                mockk(),
-                mockk()
-        )
-        val downloadedAttachments: List<Fhir3Attachment> = listOf(
-                spyk(),
-                spyk()
-        )
-        val downloadedAttachmentsIds = listOf(
-                "tomato${SPLIT_CHAR}soup",
-                "potato${SPLIT_CHAR}soup"
-        )
-
-        attachments[0].id = attachmentIds[0]
-        attachments[1].id = attachmentIds[0]
-
-        every { decryptedRecord.resource } returns resource
-        every { decryptedRecord.attachmentsKey } returns attachmentKey
-
-        every { downloadedWrappedAttachments[0].unwrap<Fhir3Attachment>() } returns downloadedAttachments[0]
-        every { downloadedWrappedAttachments[1].unwrap<Fhir3Attachment>() } returns downloadedAttachments[1]
-
-        every { downloadedWrappedAttachments[0].id } returns downloadedAttachmentsIds[0]
-        every { downloadedWrappedAttachments[1].id } returns downloadedAttachmentsIds[1]
-
-        every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
-        every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
-        every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
-        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
-        every {
-            recordService.setAttachmentIdForDownloadType(
-                    wrappedAttachments,
-                    identifiers,
-                    DownloadType.Full
-            )
-        } just Runs
-
-        every {
-            attachmentService.download(
-                    wrappedAttachments,
-                    attachmentKey,
-                    USER_ID
-            )
-        } returns Single.just(downloadedWrappedAttachments)
-
-        every {
-            recordService.updateAttachmentMeta(downloadedWrappedAttachments[0])
-        } returns downloadedWrappedAttachments[0]
-
-        every {
-            recordService.updateAttachmentMeta(downloadedWrappedAttachments[1])
-        } returns downloadedWrappedAttachments[1]
-
-        // When
-        val subscriber = recordService.downloadAttachmentsFromStorage(
-                attachmentIds,
-                USER_ID,
-                DownloadType.Full,
-                decryptedRecord
-        ).test().await()
-
-        // Then
-        val result = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .values()[0]
-
-        assertEquals(
-                actual = result.size,
-                expected = 2
-        )
-        assertEquals(
-                actual = result,
-                expected = downloadedAttachments
-        )
-
-        verifyOrder {
-            recordService.setAttachmentIdForDownloadType(
-                    wrappedAttachments,
-                    identifiers,
-                    DownloadType.Full
-            )
-            attachmentService.download(
-                    wrappedAttachments,
-                    attachmentKey,
-                    USER_ID
-            )
-            recordService.updateAttachmentMeta(downloadedWrappedAttachments[0])
-            recordService.updateAttachmentMeta(downloadedWrappedAttachments[1])
-        }
-
-        unmockkObject(SdkFhirAttachmentHelper)
-        unmockkObject(SdkAttachmentFactory)
-    }
-
-    @Test
-    fun `Given, downloadAttachment is called, with it  a RecordId, AttachmentIds, UserId and a DownloadType, it delegates the call to downloadAttachments and returns its result`() {
-        // Given
-        val attachmentId = "abc"
-        val expected: Fhir3Attachment = mockk()
-
-        every {
-            recordService.downloadAttachments(
-                    RECORD_ID,
-                    listOf(attachmentId),
-                    USER_ID,
-                    DownloadType.Full
-            )
-        } returns Single.just(listOf(expected))
-
-        // When
-        val subscriber = recordService.downloadAttachment(
-                RECORD_ID,
-                attachmentId,
-                USER_ID,
-                DownloadType.Full
-        ).test().await()
-
-        // Then
-        val result = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .values()[0]
-
-        assertSame(
-                actual = result,
-                expected = expected
-        )
-
-        verifyOrder {
-            recordService.downloadAttachments(
-                    RECORD_ID,
-                    listOf(attachmentId),
-                    USER_ID,
-                    DownloadType.Full
-            )
-        }
-    }
-
-    @Test
-    fun `Given, downloadAttachments is called with a RecordId, AttachmentIds, UserId and a DownloadType, returns encountered Attachments`() {
-        // Given
-        val userId = "asd"
-        val recordId = "ads"
-        val attachmentId = "lllll"
-        val attachmentIds = listOf(attachmentId)
-        val type = DownloadType.Medium
-
-        val response1 = mockk<Fhir3Attachment>()
-        val response2 = mockk<Fhir3Attachment>()
-        val response = listOf(response1, response2)
-
-        val encryptedRecord = mockk<EncryptedRecord>()
-        val decryptedRecord = mockk<DecryptedFhir3Record<Fhir3Resource>>()
-
-
-        every { apiService.fetchRecord(ALIAS, userId, recordId) } returns Single.just(encryptedRecord)
-        every { recordService.decryptRecord<Any>(encryptedRecord, userId) } returns decryptedRecord as DecryptedBaseRecord<Any>
-        every {
-            recordService.downloadAttachmentsFromStorage(
-                    attachmentIds,
-                    userId,
-                    type,
-                    decryptedRecord
-            )
-        } returns Single.just(response)
-
-        // When
-        val subscriber = recordService.downloadAttachments(
-                recordId,
-                attachmentIds,
-                userId,
-                type
-        ).test().await()
-
-        // Then
-        val result = subscriber
-                .assertNoErrors()
-                .assertComplete()
-                .assertValueCount(1)
-                .values()[0]
-
-        assertSame(
-                response,
-                result
-        )
-
-        verifyOrder {
-            apiService.fetchRecord(ALIAS, userId, recordId)
-            recordService.decryptRecord<Any>(encryptedRecord, userId)
-            recordService.downloadAttachmentsFromStorage(
-                    attachmentIds,
-                    userId,
-                    type,
-                    decryptedRecord
-            )
-        }
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceTest.kt
@@ -617,7 +617,10 @@ class RecordServiceTest {
         val resource: Fhir3Resource = mockk()
         val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
         val identifiers: List<Fhir3Identifier> = mockk()
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+                mockk(),
+                mockk()
+        )
         val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
                 mockk(),
                 mockk()
@@ -642,10 +645,10 @@ class RecordServiceTest {
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
         every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
         every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
-        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
         every {
             recordService.setAttachmentIdForDownloadType(
-                    attachments,
+                    wrappedAttachments,
                     identifiers,
                     DownloadType.Full
             )
@@ -653,7 +656,7 @@ class RecordServiceTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment, wrappedAttachment),
+                    wrappedAttachments,
                     attachmentKey,
                     USER_ID
             )
@@ -684,12 +687,12 @@ class RecordServiceTest {
 
         verifyOrder {
             recordService.setAttachmentIdForDownloadType(
-                    attachments,
+                    wrappedAttachments,
                     identifiers,
                     DownloadType.Full
             )
             attachmentService.download(
-                    listOf(wrappedAttachment, wrappedAttachment),
+                    wrappedAttachments,
                     attachmentKey,
                     USER_ID
             )
@@ -717,7 +720,10 @@ class RecordServiceTest {
         val resource: Fhir3Resource = mockk()
         val decryptedRecord: DecryptedFhir3Record<Fhir3Resource> = mockk()
         val identifiers: List<Fhir3Identifier> = mockk()
-        val wrappedAttachment: WrapperContract.Attachment = mockk()
+        val wrappedAttachments: List<WrapperContract.Attachment> = listOf(
+                mockk(),
+                mockk()
+        )
         val downloadedWrappedAttachments: List<WrapperContract.Attachment> = listOf(
                 mockk(),
                 mockk()
@@ -746,10 +752,10 @@ class RecordServiceTest {
         every { SdkFhirAttachmentHelper.hasAttachment(resource) } returns true
         every { SdkFhirAttachmentHelper.getAttachment(resource) } returns attachments as MutableList<Any?>
         every { SdkFhirAttachmentHelper.getIdentifier(resource) } returns identifiers
-        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returns wrappedAttachment
+        every { SdkAttachmentFactory.wrap(or(attachments[0], attachments[1])) } returnsMany wrappedAttachments
         every {
             recordService.setAttachmentIdForDownloadType(
-                    attachments,
+                    wrappedAttachments,
                     identifiers,
                     DownloadType.Full
             )
@@ -757,7 +763,7 @@ class RecordServiceTest {
 
         every {
             attachmentService.download(
-                    listOf(wrappedAttachment, wrappedAttachment),
+                    wrappedAttachments,
                     attachmentKey,
                     USER_ID
             )
@@ -796,12 +802,12 @@ class RecordServiceTest {
 
         verifyOrder {
             recordService.setAttachmentIdForDownloadType(
-                    attachments,
+                    wrappedAttachments,
                     identifiers,
                     DownloadType.Full
             )
             attachmentService.download(
-                    listOf(wrappedAttachment, wrappedAttachment),
+                    wrappedAttachments,
                     attachmentKey,
                     USER_ID
             )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is the 2nd patch of 3 to add the Fhir4 support for download Attachments and Records (excluding batch methods).
This specific PR implements the support for Fhir4 for Records in the `RecordService`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is part of [SDK-565](https://gesundheitscloud.atlassian.net/browse/SDK-565).
This depends on #104.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
This makes 3 major changes in the `RecordService`: 
 1. It splits the current entry point into 2 parts (one for each Fhir version), which is also reflected in the interface.
 2. It adds a new util method `downloadRecord` which is the agnostic against Fhir (like the already existing methods).
3. It fails if the the requested Record does not fit the Fhir Version of the entry point.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All changes had been covered by additional unit tests and the module tests had been also extended to cover the changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
