### PR TITLE
Bump Android Gradle Plugin 4.1.3 -> 4.2.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,8 @@ toc::[]
 
 === Bumped
 
+* Android Gradle Plugin 4.1.3 -> 4.2.1
+
 === Migration
 
 == https://github.com/d4l-data4life/hc-sdk-kmp/compare/v1.10.0...v1.11.0[1.11.0]

--- a/README.adoc
+++ b/README.adoc
@@ -65,10 +65,10 @@ If you just want to explore the SDK you'll find a test configuration in `sample-
 
 === Software requirements
 
-* Android 5.0.1 (API 21) to Android 10 (API 29)
-* Kotlin 1.3.72
+* Android 6.0 (API 23) to Android 11 (API 30)
+* Kotlin 1.4.32
 * Java 8 link:https://developer.android.com/studio/write/java8-support[Limitations] link:https://jakewharton.com/d8-library-desugaring/[Desugaring]
-* Gradle 6.4.1
+* Gradle 6.8.3
 
 === Dependencies
 
@@ -252,12 +252,12 @@ There are several requirements for building the SDK.
 
 === Requirements
 
-* Android 5.0.1 (API 21) to Android 10 (API 29)
-* Kotlin 1.3.72
+* Android 6.0 (API 23) to Android 11 (API 30)
+* Kotlin 1.4.32
 * Java 8 link:https://developer.android.com/studio/write/java8-support[Limitations] link:https://jakewharton.com/d8-library-desugaring/[Desugaring]
-* Gradle 6.5
-* link:https://developer.android.com/studio#downloads[Android Studio 4.1.1]
-* Android Emulator 21 - 29
+* Gradle 6.8.3
+* link:https://developer.android.com/studio#downloads[Android Studio 4.2.1]
+* Android Emulator 23 - 30
 
 **Note:** Disable Instant Run in Android Studio, or the project fails to compile.
 

--- a/auth-common/build.gradle.kts
+++ b/auth-common/build.gradle.kts
@@ -23,6 +23,12 @@ apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 group = LibraryConfig.group
 
+kotlin {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}
+
 dependencies {
     implementation(project(":securestore-common"))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,15 @@ allprojects {
     }
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+}
+
 tasks.named<Wrapper>("wrapper") {
     gradleVersion = "6.8.3"
     distributionType = Wrapper.DistributionType.ALL

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -38,7 +38,7 @@ object Versions {
 
     object GradlePlugins {
         const val kotlin = Versions.kotlin
-        const val android = "4.1.3"
+        const val android = "4.2.1"
 
         /**
          * [Dexcount](https://github.com/KeepSafe/dexcount-gradle-plugin)
@@ -54,11 +54,6 @@ object Versions {
          * [Dokka - Documentation Engine for Kotlin](https://github.com/Kotlin/dokka)
          */
         const val dokka = "0.10.1"
-
-        /**
-         * [jGitVer](https://github.com/jgitver/gradle-jgitver-plugin)
-         */
-        const val gitVersioning = "0.10.0-rc03"
 
         /**
          * [Git-Version](https://github.com/palantir/gradle-git-version)

--- a/crypto-common/build.gradle.kts
+++ b/crypto-common/build.gradle.kts
@@ -23,6 +23,12 @@ apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 group = LibraryConfig.group
 
+kotlin {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}
+
 dependencies {
     implementation(Dependencies.Multiplatform.D4L.utilCommon)
 

--- a/securestore-common/build.gradle.kts
+++ b/securestore-common/build.gradle.kts
@@ -22,6 +22,12 @@ apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 group = LibraryConfig.group
 
+kotlin {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}
+
 dependencies {
     implementation(Dependencies.Multiplatform.Kotlin.stdlibCommon)
 


### PR DESCRIPTION
## Description

Bumped Android Gradle Plugin 4.1.3 -> 4.2.1

Added Kotlin compile target configuration for Java 8

This is not solving all issues with Android Studio 4.2 due to the change to Java 11. But it's a first step and a complete fix requires the Kotlin Multiplatfrom project to be patched to new project structure.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
