### PR TITLE
[SDK-572] Add JS Legacy Encoding

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,7 +16,7 @@ toc::[]
 
 === Added
 
-* LegacyEnoding for Javascript.
+* LegacyEncoding for Javascript.
 
 === Changed
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,8 @@ toc::[]
 
 === Added
 
+* LegacyEnoding for Javascript.
+
 === Changed
 
 === Removed

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -520,7 +520,7 @@ class RecordService internal constructor(
             annotations
         )
 
-        return apiService.countRecord(
+        return apiService.countRecords(
             alias,
             userId,
             searchTags

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -114,11 +114,7 @@ class RecordService internal constructor(
         attachmentService,
         cryptoService,
         errorHandler,
-        RecordCompatibilityService(
-            apiService,
-            tagCryptoService,
-            cryptoService
-        )
+        RecordCompatibilityService(cryptoService, tagCryptoService)
     )
 
     private val recordCryptoService: NetworkModelContract.CryptoService = RecordCryptoService(
@@ -301,14 +297,14 @@ class RecordService internal constructor(
         endDate: LocalDate?,
         pageSize: Int,
         offset: Int
-    ): Single<List<BaseRecord<T>>> {
+    ): Single<List<BaseRecord<T>>> = TODO() /*{
         val startTime = if (startDate != null) dateTimeFormatter.formatDate(startDate) else null
         val endTime = if (endDate != null) dateTimeFormatter.formatDate(endDate) else null
 
         return Observable
             .fromCallable { taggingService.getTagsFromType(resourceType) }
             .flatMap { tags ->
-                compatibilityService.searchRecords(
+                apiService.searchRecords(
                     alias,
                     userId,
                     startTime,
@@ -324,7 +320,7 @@ class RecordService internal constructor(
             .map { decryptedRecord -> assignResourceId(decryptedRecord) }
             .map { decryptedRecord -> recordFactory.getInstance(decryptedRecord) }
             .toList() as Single<List<BaseRecord<T>>>
-    }
+    }*/
 
     fun <T : Fhir3Resource> fetchFhir3Records(
         userId: String,
@@ -514,12 +510,12 @@ class RecordService internal constructor(
         type: Class<out Any>,
         userId: String,
         annotations: Annotations
-    ): Single<Int> = compatibilityService.countRecords(
+    ): Single<Int> = TODO()/*compatibilityService.countRecords(
         alias,
         userId,
         taggingService.getTagsFromType(type),
         annotations
-    )
+    )*/
 
     @JvmOverloads
     @Deprecated("Deprecated with version v1.9.0 and will be removed in version v2.0.0")

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/CompatibilityEncoder.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/CompatibilityEncoder.kt
@@ -16,20 +16,20 @@
 
 package care.data4life.sdk.migration
 
-import care.data4life.sdk.migration.MigrationContract.CompatibilityEncoder.Companion.JS_LEGACY_ENCODING_EXCEPTIONS
+import care.data4life.sdk.migration.MigrationContract.CompatibilityEncoder.Companion.JS_LEGACY_ENCODING_REPLACEMENTS
 import care.data4life.sdk.tag.TagEncoding
 import care.data4life.sdk.tag.TaggingContract
-import care.data4life.sdk.wrapper.URLEncoding
+import care.data4life.sdk.wrapper.UrlEncoding
 import care.data4life.sdk.wrapper.WrapperContract
 
 internal object CompatibilityEncoder : MigrationContract.CompatibilityEncoder {
     private val tagEncoding: TaggingContract.Encoding = TagEncoding
-    private val urlEncoding: WrapperContract.URLEncoding = URLEncoding
+    private val urlEncoding: WrapperContract.UrlEncoding = UrlEncoding
 
     private fun mapJSExceptions(encodedTag: String): String {
         var result = encodedTag
 
-        JS_LEGACY_ENCODING_EXCEPTIONS.entries.forEach { replacement ->
+        JS_LEGACY_ENCODING_REPLACEMENTS.entries.forEach { replacement ->
             result = result.replace(replacement.key, replacement.value)
         }
 
@@ -38,14 +38,14 @@ internal object CompatibilityEncoder : MigrationContract.CompatibilityEncoder {
 
     override fun encode(tagValue: String): Triple<String, String, String> {
         val validEncoding = tagEncoding.encode(tagValue)
-        val normalizedTag = tagEncoding.normalize(tagValue)
+        val kmpLegacyEncoding = tagEncoding.normalize(tagValue)
         val jsLegacyEncoding = mapJSExceptions(
-            urlEncoding.encode(normalizedTag)
+            urlEncoding.encode(kmpLegacyEncoding)
         )
 
         return Triple(
             validEncoding,
-            normalizedTag, // aka KMPLegacyTags
+            kmpLegacyEncoding, // aka KMPLegacyTags
             jsLegacyEncoding
         )
     }

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/CompatibilityEncoder.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/CompatibilityEncoder.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.migration
+
+import care.data4life.sdk.migration.MigrationContract.CompatibilityEncoder.Companion.JS_LEGACY_ENCODING_EXCEPTIONS
+import care.data4life.sdk.tag.TagEncoding
+import care.data4life.sdk.tag.TaggingContract
+import care.data4life.sdk.wrapper.URLEncoding
+import care.data4life.sdk.wrapper.WrapperContract
+
+internal object CompatibilityEncoder : MigrationContract.CompatibilityEncoder {
+    private val tagEncoding: TaggingContract.Encoding = TagEncoding
+    private val urlEncoding: WrapperContract.URLEncoding = URLEncoding
+
+    private fun mapJSExceptions(encodedTag: String): String {
+        var result = encodedTag
+
+        JS_LEGACY_ENCODING_EXCEPTIONS.entries.forEach { replacement ->
+            result = result.replace(replacement.key, replacement.value)
+        }
+
+        return result
+    }
+
+    override fun encode(tagValue: String): Triple<String, String, String> {
+        val validEncoding = tagEncoding.encode(tagValue)
+        val normalizedTag = tagEncoding.normalize(tagValue)
+        val jsLegacyEncoding = mapJSExceptions(
+            urlEncoding.encode(normalizedTag)
+        )
+
+        return Triple(
+            validEncoding,
+            normalizedTag, // aka KMPLegacyTags
+            jsLegacyEncoding
+        )
+    }
+
+    override fun normalize(tagValue: String): String = tagEncoding.normalize(tagValue)
+}

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
@@ -16,11 +16,9 @@
 
 package care.data4life.sdk.migration
 
-import care.data4life.sdk.network.model.NetworkModelContract
+import care.data4life.sdk.network.NetworkingContract
 import care.data4life.sdk.tag.Annotations
 import care.data4life.sdk.tag.Tags
-import io.reactivex.Observable
-import io.reactivex.Single
 
 @Retention(AnnotationRetention.SOURCE)
 @MustBeDocumented
@@ -28,23 +26,10 @@ annotation class Migration(val message: String)
 
 class MigrationContract {
     interface CompatibilityService {
-        fun searchRecords(
-            alias: String,
-            userId: String,
-            startDate: String?,
-            endDate: String?,
-            pageSize: Int,
-            offSet: Int,
+        fun resolveSearchTags(
             tags: Tags,
-            annotations: Annotations
-        ): Observable<List<NetworkModelContract.EncryptedRecord>>
-
-        fun countRecords(
-            alias: String,
-            userId: String,
-            tags: Tags,
-            annotations: Annotations
-        ): Single<Int>
+            annotation: Annotations
+        ): NetworkingContract.SearchTags
     }
 
     internal interface CompatibilityEncoder {

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
@@ -46,4 +46,16 @@ interface MigrationContract {
             annotations: Annotations
         ): Single<Int>
     }
+
+    interface LegacyTagEncoder {
+        companion object {
+            val JS_LEGACY_ENCODING_EXCEPTIONS = listOf(
+                "%2a",
+                "%2d",
+                "%2e",
+                "%5f",
+                "%7e"
+            )
+        }
+    }
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
@@ -26,7 +26,7 @@ import io.reactivex.Single
 @MustBeDocumented
 annotation class Migration(val message: String)
 
-interface MigrationContract {
+class MigrationContract {
     interface CompatibilityService {
         fun searchRecords(
             alias: String,
@@ -47,14 +47,17 @@ interface MigrationContract {
         ): Single<Int>
     }
 
-    interface LegacyTagEncoder {
+    internal interface CompatibilityEncoder {
+        fun encode(tagValue: String): Triple<String, String, String>
+        fun normalize(tagValue: String): String
+
         companion object {
-            val JS_LEGACY_ENCODING_EXCEPTIONS = listOf(
-                "%2a",
-                "%2d",
-                "%2e",
-                "%5f",
-                "%7e"
+            val JS_LEGACY_ENCODING_EXCEPTIONS = mapOf(
+                "%2A" to "%2a",
+                "%2D" to "%2d",
+                "%2E" to "%2e",
+                "%5F" to "%5f",
+                "%7E" to "%7e"
             )
         }
     }

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/MigrationContract.kt
@@ -37,7 +37,7 @@ class MigrationContract {
         fun normalize(tagValue: String): String
 
         companion object {
-            val JS_LEGACY_ENCODING_EXCEPTIONS = mapOf(
+            val JS_LEGACY_ENCODING_REPLACEMENTS = mapOf(
                 "%2A" to "%2a",
                 "%2D" to "%2d",
                 "%2E" to "%2e",

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/RecordCompatibilityService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/RecordCompatibilityService.kt
@@ -22,7 +22,7 @@ import care.data4life.sdk.network.NetworkingContract
 import care.data4life.sdk.network.model.NetworkModelContract.EncryptedRecord
 import care.data4life.sdk.tag.Annotations
 import care.data4life.sdk.tag.EncryptedTagsAndAnnotations
-import care.data4life.sdk.tag.TagCryptoHelper
+import care.data4life.sdk.tag.TagEncoding
 import care.data4life.sdk.tag.TaggingContract
 import care.data4life.sdk.tag.TaggingContract.Companion.ANNOTATION_KEY
 import care.data4life.sdk.tag.Tags
@@ -37,7 +37,7 @@ class RecordCompatibilityService internal constructor(
     private val apiService: NetworkingContract.Service,
     private val tagCryptoService: TaggingContract.CryptoService,
     private val cryptoService: CryptoContract.Service,
-    private val tagHelper: TaggingContract.Helper = TagCryptoHelper
+    private val tagEncoding: TaggingContract.Encoding = TagEncoding
 ) : MigrationContract.CompatibilityService {
     private fun encrypt(
         plainTags: Tags,
@@ -62,7 +62,7 @@ class RecordCompatibilityService internal constructor(
     @Throws(IOException::class)
     private fun encryptTags(tags: Tags, tagEncryptionKey: GCKey): MutableList<String> {
         return tags
-            .map { entry -> entry.key + TaggingContract.DELIMITER + tagHelper.normalize(entry.value) }
+            .map { entry -> entry.key + TaggingContract.DELIMITER + tagEncoding.normalize(entry.value) }
             .let { normalizedTags ->
                 tagCryptoService.encryptList(
                     normalizedTags,

--- a/sdk-core/src/main/java/care/data4life/sdk/migration/RecordCompatibilityService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/migration/RecordCompatibilityService.kt
@@ -19,138 +19,80 @@ package care.data4life.sdk.migration
 import care.data4life.crypto.GCKey
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.network.NetworkingContract
-import care.data4life.sdk.network.model.NetworkModelContract.EncryptedRecord
+import care.data4life.sdk.network.util.SearchTagsBuilder
 import care.data4life.sdk.tag.Annotations
-import care.data4life.sdk.tag.EncryptedTagsAndAnnotations
-import care.data4life.sdk.tag.TagEncoding
 import care.data4life.sdk.tag.TaggingContract
 import care.data4life.sdk.tag.TaggingContract.Companion.ANNOTATION_KEY
+import care.data4life.sdk.tag.TaggingContract.Companion.DELIMITER
 import care.data4life.sdk.tag.Tags
-import io.reactivex.Observable
-import io.reactivex.Single
-import io.reactivex.functions.BiFunction
-import java.io.IOException
 
+// see: https://gesundheitscloud.atlassian.net/browse/SDK-572
 // see: https://gesundheitscloud.atlassian.net/browse/SDK-525
 @Migration("This class should only be used due to migration purpose.")
 class RecordCompatibilityService internal constructor(
-    private val apiService: NetworkingContract.Service,
-    private val tagCryptoService: TaggingContract.CryptoService,
     private val cryptoService: CryptoContract.Service,
-    private val tagEncoding: TaggingContract.Encoding = TagEncoding
+    private val tagCryptoService: TaggingContract.CryptoService,
+    private val compatibilityEncoder: MigrationContract.CompatibilityEncoder = CompatibilityEncoder,
+    private val searchTagsBuilderFactory: NetworkingContract.SearchTagsBuilderFactory = SearchTagsBuilder
 ) : MigrationContract.CompatibilityService {
-    private fun encrypt(
-        plainTags: Tags,
-        plainAnnotations: Annotations
-    ): Pair<EncryptedTagsAndAnnotations, EncryptedTagsAndAnnotations> {
-        val tagEncryptionKey = cryptoService.fetchTagEncryptionKey()
-        return Pair(
-            tagCryptoService.encryptTagsAndAnnotations(
-                plainTags,
-                plainAnnotations,
-                tagEncryptionKey
-            ),
-            encryptTags(plainTags, tagEncryptionKey)
-                .also { encryptedTags ->
-                    encryptedTags.addAll(
-                        encryptAnnotations(plainAnnotations, tagEncryptionKey)
-                    )
-                }
-        )
-    }
-
-    @Throws(IOException::class)
-    private fun encryptTags(tags: Tags, tagEncryptionKey: GCKey): MutableList<String> {
-        return tags
-            .map { entry -> entry.key + TaggingContract.DELIMITER + tagEncoding.normalize(entry.value) }
-            .let { normalizedTags ->
-                tagCryptoService.encryptList(
-                    normalizedTags,
-                    tagEncryptionKey
-                )
-            }
-    }
-
-    @Throws(IOException::class)
-    private fun encryptAnnotations(
-        annotations: Annotations,
-        tagEncryptionKey: GCKey
-    ): MutableList<String> {
+    private fun encryptTags(
+        tagEncryptionKey: GCKey,
+        tagGroupKey: String,
+        tagOrGroup: Triple<String, String, String>
+    ): List<String> {
         return tagCryptoService.encryptList(
-            annotations,
+            tagOrGroup.toList(),
             tagEncryptionKey,
-            ANNOTATION_KEY + TaggingContract.DELIMITER
+            tagGroupKey
         )
     }
 
-    private fun needsDoubleCall(
-        encodedAndEncryptedTags: List<String>,
-        encryptedTags: List<String>
-    ): Boolean = encodedAndEncryptedTags.sorted() != encryptedTags.sorted()
-
-    override fun searchRecords(
-        alias: String,
-        userId: String,
-        startDate: String?,
-        endDate: String?,
-        pageSize: Int,
-        offSet: Int,
+    private fun mapTags(
         tags: Tags,
-        annotations: Annotations
-    ): Observable<List<EncryptedRecord>> {
-        val (encodedAndEncryptedTags, encryptedTags) = encrypt(tags, annotations)
-        return if (needsDoubleCall(encodedAndEncryptedTags, encryptedTags)) {
-            Observable.zip(
-                apiService.searchRecords(
-                    alias,
-                    userId,
-                    startDate,
-                    endDate,
-                    pageSize,
-                    offSet,
-                    encodedAndEncryptedTags.joinToString(",")
-                ),
-                apiService.searchRecords(
-                    alias,
-                    userId,
-                    startDate,
-                    endDate,
-                    pageSize,
-                    offSet,
-                    encryptedTags.joinToString(",")
-                ),
-                BiFunction<List<EncryptedRecord>, List<EncryptedRecord>, List<EncryptedRecord>> { records1, records2 ->
-                    mutableListOf<EncryptedRecord>().also {
-                        it.addAll(records1)
-                        it.addAll(records2)
-                    }
-                }
+        tagEncryptionKey: GCKey
+    ): List<List<String>> {
+        return tags.map { tagGroup ->
+            Pair(
+                tagGroup.key + DELIMITER,
+                compatibilityEncoder.encode(tagGroup.value)
             )
-        } else {
-            apiService.searchRecords(
-                alias,
-                userId,
-                startDate,
-                endDate,
-                pageSize,
-                offSet,
-                encodedAndEncryptedTags.joinToString(",")
-            ) as Observable<List<EncryptedRecord>>
+        }.map { encodedTagGroup ->
+            encryptTags(
+                tagEncryptionKey,
+                encodedTagGroup.first,
+                encodedTagGroup.second
+            )
         }
     }
 
-    override fun countRecords(
-        alias: String,
-        userId: String,
-        tags: Tags,
-        annotations: Annotations
-    ): Single<Int> {
-        val (encodedAndEncryptedTags, encryptedTags) = encrypt(tags, annotations)
+    private fun mapAnnotations(
+        annotations: Annotations,
+        tagEncryptionKey: GCKey
+    ): List<List<String>> {
+        return annotations.map { annotation ->
+            Pair(
+                ANNOTATION_KEY + DELIMITER,
+                compatibilityEncoder.encode(annotation).copy(second = annotation)
+            )
+        }.map { encodedTagGroup ->
+            encryptTags(
+                tagEncryptionKey,
+                encodedTagGroup.first,
+                encodedTagGroup.second
+            )
+        }
+    }
 
-        return Single.zip(
-            apiService.getCount(alias, userId, encodedAndEncryptedTags.joinToString(",")),
-            apiService.getCount(alias, userId, encryptedTags.joinToString(",")),
-            BiFunction<Int, Int, Int> { c1, c2 -> c1 + c2 }
-        )
+    override fun resolveSearchTags(
+        tags: Tags,
+        annotation: Annotations
+    ): NetworkingContract.SearchTags {
+        val builder = searchTagsBuilderFactory.newBuilder()
+        val tagEncryptionKey = cryptoService.fetchTagEncryptionKey()
+
+        mapTags(tags, tagEncryptionKey).forEach { tagGroup -> builder.addOrTuple(tagGroup) }
+        mapAnnotations(annotation, tagEncryptionKey).forEach { tagGroup -> builder.addOrTuple(tagGroup) }
+
+        return builder.seal()
     }
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/network/ApiService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/network/ApiService.kt
@@ -229,7 +229,7 @@ class ApiService constructor(
         )
     }
 
-    override fun countRecord(
+    override fun countRecords(
         alias: String,
         userId: String,
         tags: NetworkingContract.SearchTags

--- a/sdk-core/src/main/java/care/data4life/sdk/network/ApiService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/network/ApiService.kt
@@ -216,14 +216,26 @@ class ApiService constructor(
         endDate: String?,
         pageSize: Int,
         offset: Int,
-        tags: String
+        tags: NetworkingContract.SearchTags
     ): Observable<List<EncryptedRecord>> {
-        return service!!.searchRecords(alias, userId, startDate, endDate, pageSize, offset, tags)
+        return service!!.searchRecords(
+            alias,
+            userId,
+            startDate,
+            endDate,
+            pageSize,
+            offset,
+            tags.tags
+        )
     }
 
-    override fun getCount(alias: String, userId: String, tags: String): Single<Int> {
+    override fun countRecord(
+        alias: String,
+        userId: String,
+        tags: NetworkingContract.SearchTags
+    ): Single<Int> {
         return service!!
-            .getRecordsHeader(alias, userId, tags)
+            .getRecordsHeader(alias, userId, tags.tags)
             .map { response ->
                 response.headers()[NetworkingContract.HEADER_TOTAL_COUNT]!!
                     .toInt()

--- a/sdk-core/src/main/java/care/data4life/sdk/network/NetworkingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/network/NetworkingContract.kt
@@ -61,7 +61,7 @@ interface NetworkingContract {
             tags: SearchTags
         ): Observable<List<EncryptedRecord>>
 
-        fun countRecord(alias: String, userId: String, tags: SearchTags): Single<Int>
+        fun countRecords(alias: String, userId: String, tags: SearchTags): Single<Int>
 
         fun deleteRecord(alias: String, recordId: String, userId: String): Completable
 

--- a/sdk-core/src/main/java/care/data4life/sdk/network/NetworkingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/network/NetworkingContract.kt
@@ -127,6 +127,19 @@ interface NetworkingContract {
         fun fromName(name: String?): Environment
     }
 
+    interface SearchTagsBuilder {
+        fun addOrTuple(tuple: List<String>): SearchTagsBuilder
+        fun seal(): SearchTags
+    }
+
+    interface SearchTags {
+        val tags: String
+    }
+
+    interface SearchTagsBuilderFactory {
+        fun newBuilder(): SearchTagsBuilder
+    }
+
     companion object {
         const val PLATFORM_D4L = "d4l"
         const val PLATFORM_S4H = "s4h"

--- a/sdk-core/src/main/java/care/data4life/sdk/network/NetworkingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/network/NetworkingContract.kt
@@ -58,10 +58,10 @@ interface NetworkingContract {
             endDate: String?,
             pageSize: Int,
             offset: Int,
-            tags: String
+            tags: SearchTags
         ): Observable<List<EncryptedRecord>>
 
-        fun getCount(alias: String, userId: String, tags: String): Single<Int>
+        fun countRecord(alias: String, userId: String, tags: SearchTags): Single<Int>
 
         fun deleteRecord(alias: String, recordId: String, userId: String): Completable
 

--- a/sdk-core/src/main/java/care/data4life/sdk/network/util/SearchTagsBuilder.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/network/util/SearchTagsBuilder.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.network.util
+
+import care.data4life.sdk.network.NetworkingContract
+
+data class SearchTags(
+    override val tags: String
+) : NetworkingContract.SearchTags
+
+class SearchTagsBuilder private constructor() : NetworkingContract.SearchTagsBuilder {
+    private val orTuples: MutableList<List<String>> = mutableListOf()
+
+    override fun addOrTuple(tuple: List<String>): NetworkingContract.SearchTagsBuilder {
+        orTuples.add(tuple)
+        return this
+    }
+
+    private fun joinTuples(
+        tuple: List<String>
+    ): String {
+        val unified = tuple.toSet()
+
+        return if (unified.size > 1) {
+            "(${unified.joinToString(",")})"
+        } else {
+            unified.joinToString(",")
+        }
+    }
+
+    private fun formatTags(): String {
+        return orTuples
+            .toSet()
+            .joinToString(",", transform = ::joinTuples)
+    }
+
+    override fun seal(): NetworkingContract.SearchTags = SearchTags(formatTags())
+
+    companion object Factory : NetworkingContract.SearchTagsBuilderFactory {
+        override fun newBuilder(): NetworkingContract.SearchTagsBuilder = SearchTagsBuilder()
+    }
+}

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TagConverter.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TagConverter.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.tag
+
+object TagConverter : TaggingContract.Converter {
+    override fun toTags(tagList: List<String>): Tags {
+        val tags = mutableMapOf<String, String>()
+        for (entry in tagList) {
+            val split = entry.split(TaggingContract.DELIMITER)
+            if (split.size == 2) {
+                val key = split[0]
+                val value = split[1]
+                if (key.isNotBlank() && value.isNotBlank()) {
+                    tags[key] = value
+                }
+            }
+        }
+        return tags
+    }
+}

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
@@ -19,7 +19,6 @@ import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.lang.DataValidationException
 import care.data4life.sdk.tag.TaggingContract.Companion.LOCALE
 import care.data4life.sdk.wrapper.URLEncoding
-import java.util.Locale
 
 object TagEncoding : TaggingContract.Encoding {
     @Throws(D4LException::class)

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
@@ -17,33 +17,18 @@ package care.data4life.sdk.tag
 
 import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.lang.DataValidationException
-import care.data4life.sdk.tag.TaggingContract.Companion.DELIMITER
 import okhttp3.internal.toHexString
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.Locale
 
-object TagCryptoHelper : TaggingContract.Helper {
-    override fun convertToTagMap(tagList: List<String>): Tags {
-        val tags = HashMap<String, String>()
-        for (entry in tagList) {
-            val split = entry.split(DELIMITER)
-            if (split.size == 2) {
-                val key = split[0]
-                val value = split[1]
-                if (key.isNotBlank() && value.isNotBlank()) {
-                    tags[key] = value
-                }
-            }
-        }
-        return tags
-    }
+object TagEncoding : TaggingContract.Encoding {
+    private val specialChars = listOf('*', '-', '_', '.')
 
     private fun normalizeEncodedChar(char: Char): Char = char.toLowerCase()
 
     private fun replaceSpecial(char: Char): String {
-        val specialChars = listOf('*', '-', '_', '.')
         return when (char) {
             '+' -> "%20"
             in specialChars -> "%${char.toInt().toHexString()}"

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
@@ -18,7 +18,7 @@ package care.data4life.sdk.tag
 import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.lang.DataValidationException
 import care.data4life.sdk.tag.TaggingContract.Companion.LOCALE
-import care.data4life.sdk.wrapper.URLEncoding
+import care.data4life.sdk.wrapper.UrlEncoding
 
 object TagEncoding : TaggingContract.Encoding {
     @Throws(D4LException::class)
@@ -33,7 +33,7 @@ object TagEncoding : TaggingContract.Encoding {
     @Throws(D4LException::class)
     override fun encode(
         tag: String
-    ): String = URLEncoding.encode(normalize(tag)).toLowerCase(LOCALE)
+    ): String = UrlEncoding.encode(normalize(tag)).toLowerCase(LOCALE)
 
     @Throws(D4LException::class)
     override fun normalize(tag: String): String {
@@ -43,5 +43,5 @@ object TagEncoding : TaggingContract.Encoding {
 
     override fun decode(
         encodedTag: String
-    ): String = URLEncoding.decode(encodedTag)
+    ): String = UrlEncoding.decode(encodedTag)
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TagEncoding.kt
@@ -17,25 +17,11 @@ package care.data4life.sdk.tag
 
 import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.lang.DataValidationException
-import okhttp3.internal.toHexString
-import java.net.URLDecoder
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
+import care.data4life.sdk.tag.TaggingContract.Companion.LOCALE
+import care.data4life.sdk.wrapper.URLEncoding
 import java.util.Locale
 
 object TagEncoding : TaggingContract.Encoding {
-    private val specialChars = listOf('*', '-', '_', '.')
-
-    private fun normalizeEncodedChar(char: Char): Char = char.toLowerCase()
-
-    private fun replaceSpecial(char: Char): String {
-        return when (char) {
-            '+' -> "%20"
-            in specialChars -> "%${char.toInt().toHexString()}"
-            else -> char.toString()
-        }
-    }
-
     @Throws(D4LException::class)
     private fun validateTag(tag: String) {
         if (tag.isBlank()) {
@@ -46,24 +32,17 @@ object TagEncoding : TaggingContract.Encoding {
     }
 
     @Throws(D4LException::class)
-    override fun encode(tag: String): String {
-        return URLEncoder.encode(
-            normalize(tag),
-            StandardCharsets.UTF_8.displayName()
-        ).map { char ->
-            replaceSpecial(
-                normalizeEncodedChar(char)
-            )
-        }.joinToString("")
-    }
+    override fun encode(
+        tag: String
+    ): String = URLEncoding.encode(normalize(tag)).toLowerCase(LOCALE)
 
     @Throws(D4LException::class)
     override fun normalize(tag: String): String {
         validateTag(tag)
-        return tag.toLowerCase(Locale.US).trim()
+        return tag.toLowerCase(LOCALE).trim()
     }
 
     override fun decode(
         encodedTag: String
-    ): String = URLDecoder.decode(encodedTag, StandardCharsets.UTF_8.displayName())
+    ): String = URLEncoding.decode(encodedTag)
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
@@ -20,6 +20,7 @@ import care.data4life.crypto.GCKey
 import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.migration.Migration
 import java.io.IOException
+import java.util.Locale
 
 typealias Tags = Map<String, String>
 typealias Annotations = List<String>
@@ -57,7 +58,8 @@ class TaggingContract {
         }
     }
 
-    interface Converter {
+    // TODO: make this package internal
+    fun interface Converter {
         @Throws(D4LException::class)
         fun toTags(tagList: List<String>): Tags
     }
@@ -84,6 +86,7 @@ class TaggingContract {
         const val TAG_FHIR_VERSION = "fhirversion"
         const val TAG_APPDATA_KEY = "flag"
         const val TAG_APPDATA_VALUE = "appdata"
+        val LOCALE: Locale = Locale.US
         const val SEPARATOR = "#"
     }
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/tag/TaggingContract.kt
@@ -51,16 +51,22 @@ class TaggingContract {
             encryptionKey: GCKey,
             prefix: String = ""
         ): MutableList<String>
+
+        companion object {
+            internal val IV = ByteArray(16)
+        }
+    }
+
+    interface Converter {
+        @Throws(D4LException::class)
+        fun toTags(tagList: List<String>): Tags
     }
 
     // TODO: make this package internal
-    interface Helper {
-        fun convertToTagMap(tagList: List<String>): Tags
-
+    interface Encoding {
         @Throws(D4LException::class)
         fun encode(tag: String): String
 
-        @Throws(D4LException::class)
         @Migration("This method should only be used for migration purpose.")
         fun normalize(tag: String): String
 

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/URLEncoding.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/URLEncoding.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.wrapper
+
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+private fun Int.toHex(): String = Integer.toHexString(this).toUpperCase(Locale.US)
+
+object URLEncoding : WrapperContract.URLEncoding {
+    private val specialChars = listOf('*', '-', '_', '.')
+
+    private fun replaceSpecial(char: Char): String {
+        return when (char) {
+            '+' -> "%20"
+            in specialChars -> "%${char.toInt().toHex() }"
+            else -> char.toString()
+        }
+    }
+
+    override fun encode(str: String): String {
+        return URLEncoder.encode(str, StandardCharsets.UTF_8.displayName())
+            .map(::replaceSpecial)
+            .joinToString("")
+    }
+
+    override fun decode(
+        str: String
+    ): String = URLDecoder.decode(str, StandardCharsets.UTF_8.displayName())
+}

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/URLEncoding.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/URLEncoding.kt
@@ -23,7 +23,7 @@ import java.util.Locale
 
 private fun Int.toHex(): String = Integer.toHexString(this).toUpperCase(Locale.US)
 
-object URLEncoding : WrapperContract.URLEncoding {
+object UrlEncoding : WrapperContract.UrlEncoding {
     private val specialChars = listOf('*', '-', '_', '.')
 
     private fun replaceSpecial(char: Char): String {

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
@@ -74,4 +74,10 @@ class WrapperContract {
             const val DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss[.SSS]"
         }
     }
+
+    // TODO: Move that to kmp utils repo
+    interface URLEncoding {
+        fun encode(str: String): String
+        fun decode(str: String): String
+    }
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
@@ -76,7 +76,7 @@ class WrapperContract {
     }
 
     // TODO: Move that to kmp utils repo
-    interface URLEncoding {
+    interface UrlEncoding {
         fun encode(str: String): String
         fun decode(str: String): String
     }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsModuleTest.kt
@@ -126,7 +126,7 @@ class RecordServiceCountRecordsModuleTest {
         val search = slot<NetworkingContract.SearchTags>()
 
         every {
-            apiService.countRecord(
+            apiService.countRecords(
                 alias,
                 userId,
                 capture(search)

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsModuleTest.kt
@@ -22,6 +22,7 @@ import care.data4life.sdk.attachment.AttachmentService
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.fhir.ResourceCryptoService
 import care.data4life.sdk.network.NetworkingContract
+import care.data4life.sdk.network.util.SearchTagsBuilder
 import care.data4life.sdk.record.RecordContract
 import care.data4life.sdk.tag.Annotations
 import care.data4life.sdk.tag.TagCryptoService
@@ -85,23 +86,21 @@ class RecordServiceCountRecordsModuleTest {
     private fun runFlow(
         tags: Tags,
         annotations: Annotations = emptyList(),
-        amounts: Pair<Int, Int>,
+        amount: Int,
         alias: String = ALIAS,
         userId: String = USER_ID,
         tagEncryptionKey: GCKey = this.tagEncryptionKey
     ) {
-        val (encodedTags, legacyTags) = flowHelper.prepareCompatibilityTags(tags)
-        val (encodedAnnotations, legacyAnnotations) = flowHelper.prepareCompatibilityAnnotations(
+        val (encodedTags, legacyKMPTags, legacyJSTags) = flowHelper.prepareCompatibilityTags(tags)
+        val (encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations) = flowHelper.prepareCompatibilityAnnotations(
             annotations
         )
 
-        val encryptedTagsAndAnnotations = flowHelper.hashAndEncodeTagsAndAnnotations(
-            flowHelper.mergeTags(encodedTags, encodedAnnotations)
-        )
-
-        val encryptedLegacyTagsAndAnnotations = flowHelper.hashAndEncodeTagsAndAnnotations(
-            flowHelper.mergeTags(legacyTags, legacyAnnotations)
-        )
+        val searchTags = SearchTagsBuilder.newBuilder()
+            .let { flowHelper.buildExpectedTagGroups(it, encodedTags, legacyKMPTags, legacyJSTags) }
+            .let { flowHelper.buildExpectedTagGroups(it, encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations) }
+            .seal()
+            .tags
 
         val receivedIteration = CryptoServiceIteration(
             gcKeyOrder = emptyList(),
@@ -117,32 +116,35 @@ class RecordServiceCountRecordsModuleTest {
             tagEncryptionKey = tagEncryptionKey,
             tagEncryptionKeyCalls = 1,
             resources = emptyList(),
-            tags = flowHelper.mergeTags(encodedTags, legacyTags),
-            annotations = flowHelper.mergeTags(encodedAnnotations, legacyAnnotations),
+            tags = flowHelper.mergeTags(encodedTags, legacyKMPTags, legacyJSTags),
+            annotations = flowHelper.mergeTags(encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations),
             hashFunction = { value -> flowHelper.md5(value) }
         )
 
         (cryptoService as CryptoServiceFake).iteration = receivedIteration
 
-        val search = slot<String>()
+        val search = slot<NetworkingContract.SearchTags>()
 
         every {
-            apiService.getCount(
+            apiService.countRecord(
                 alias,
                 userId,
                 capture(search)
             )
         } answers {
-            val actual = search.captured
-            val amount = when {
-                flowHelper.compareSerialisedTags(actual, encryptedTagsAndAnnotations) -> amounts.first
-                flowHelper.compareSerialisedTags(actual, encryptedLegacyTagsAndAnnotations) -> amounts.second
-                else -> throw RuntimeException(
-                    "Unexpected tags and annotations:\n$actual"
+            val actual = flowHelper.decryptSerializedTags(
+                search.captured.tags,
+                cryptoService,
+                tagEncryptionKey
+            )
+
+            if (searchTags == actual) {
+                Single.just(amount)
+            } else {
+                throw RuntimeException(
+                    "Unexpected tags and annotations - \nexpected: $searchTags\ngot: $actual"
                 )
             }
-
-            Single.just(amount)
         }
     }
 
@@ -158,7 +160,7 @@ class RecordServiceCountRecordsModuleTest {
 
         runFlow(
             tags = tags,
-            amounts = Pair(21, 21)
+            amount = 42
         )
 
         // When
@@ -195,7 +197,7 @@ class RecordServiceCountRecordsModuleTest {
         runFlow(
             tags = tags,
             annotations = annotations,
-            amounts = Pair(12, 11)
+            amount = 23
         )
 
         // When
@@ -223,7 +225,7 @@ class RecordServiceCountRecordsModuleTest {
 
         runFlow(
             tags = tags,
-            amounts = Pair(21, 21)
+            amount = 42
         )
 
         // When
@@ -260,7 +262,7 @@ class RecordServiceCountRecordsModuleTest {
         runFlow(
             tags = tags,
             annotations = annotations,
-            amounts = Pair(12, 11)
+            amount = 23
         )
 
         // When
@@ -295,7 +297,7 @@ class RecordServiceCountRecordsModuleTest {
         runFlow(
             tags = tags,
             annotations = annotations,
-            amounts = Pair(12, 11)
+            amount = 23
         )
 
         // When
@@ -323,7 +325,7 @@ class RecordServiceCountRecordsModuleTest {
 
         runFlow(
             tags = tags,
-            amounts = Pair(23, 23)
+            amount = 46
         )
 
         // When
@@ -360,7 +362,7 @@ class RecordServiceCountRecordsModuleTest {
         runFlow(
             tags = tags,
             annotations = annotations,
-            amounts = Pair(12, 11)
+            amount = 23
         )
 
         // When

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -85,7 +85,7 @@ class RecordServiceCountRecordsTest {
 
         every { taggingService.getTagsFromType(Fhir3Resource::class.java as Class<Any>) } returns tags
         every { compatibilityService.resolveSearchTags(tags, annotations) } returns searchTags
-        every { apiService.getCount(ALIAS, USER_ID, searchTags) } returns Single.just(expected)
+        every { apiService.countRecords(ALIAS, USER_ID, searchTags) } returns Single.just(expected)
 
         // When
         val observer = recordService.countFhir3Records(
@@ -107,7 +107,7 @@ class RecordServiceCountRecordsTest {
         )
         verify(exactly = 1) { taggingService.getTagsFromType(Fhir3Resource::class.java as Class<Any>) }
         verify(exactly = 1) { compatibilityService.resolveSearchTags(tags, annotations) }
-        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, searchTags) }
+        verify(exactly = 1) { apiService.countRecords(ALIAS, USER_ID, searchTags) }
     }
 
     @Test
@@ -120,7 +120,7 @@ class RecordServiceCountRecordsTest {
 
         every { taggingService.getTagsFromType(Fhir4Resource::class.java as Class<Any>) } returns tags
         every { compatibilityService.resolveSearchTags(tags, annotations) } returns searchTags
-        every { apiService.getCount(ALIAS, USER_ID, searchTags) } returns Single.just(expected)
+        every { apiService.countRecords(ALIAS, USER_ID, searchTags) } returns Single.just(expected)
 
         // When
         val observer = recordService.countFhir4Records(
@@ -142,7 +142,7 @@ class RecordServiceCountRecordsTest {
         )
         verify(exactly = 1) { taggingService.getTagsFromType(Fhir4Resource::class.java as Class<Any>) }
         verify(exactly = 1) { compatibilityService.resolveSearchTags(tags, annotations) }
-        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, searchTags) }
+        verify(exactly = 1) { apiService.countRecords(ALIAS, USER_ID, searchTags) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -79,18 +79,13 @@ class RecordServiceCountRecordsTest {
     @Throws(InterruptedException::class, IOException::class)
     fun `Given, countFhir3Records is called with a Fhir3Resource, a UserId and Annotations, it returns amount of occurrences`() {
         // Given
-        /*val expected = 42
+        val expected = 42
         val annotations: Annotations = mockk()
+        val searchTags: NetworkingContract.SearchTags = mockk()
 
         every { taggingService.getTagsFromType(Fhir3Resource::class.java as Class<Any>) } returns tags
-        every {
-            compatibilityService.countRecords(
-                ALIAS,
-                USER_ID,
-                tags,
-                annotations
-            )
-        } returns Single.just(expected)
+        every { compatibilityService.resolveSearchTags(tags, annotations) } returns searchTags
+        every { apiService.getCount(ALIAS, USER_ID, searchTags) } returns Single.just(expected)
 
         // When
         val observer = recordService.countFhir3Records(
@@ -111,25 +106,21 @@ class RecordServiceCountRecordsTest {
             actual = result
         )
         verify(exactly = 1) { taggingService.getTagsFromType(Fhir3Resource::class.java as Class<Any>) }
-        verify(exactly = 1) { compatibilityService.countRecords(ALIAS, USER_ID, tags, annotations) }*/
+        verify(exactly = 1) { compatibilityService.resolveSearchTags(tags, annotations) }
+        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, searchTags) }
     }
 
     @Test
     @Throws(InterruptedException::class, IOException::class)
     fun `Given, countFhir4Records is called with a Fhir4Resource, a UserId and Annotations, it returns amount of occurrences`() {
         // Given
-        /*val expected = 42
+        val expected = 42
         val annotations: Annotations = mockk()
+        val searchTags: NetworkingContract.SearchTags = mockk()
 
         every { taggingService.getTagsFromType(Fhir4Resource::class.java as Class<Any>) } returns tags
-        every {
-            compatibilityService.countRecords(
-                ALIAS,
-                USER_ID,
-                tags,
-                annotations
-            )
-        } returns Single.just(expected)
+        every { compatibilityService.resolveSearchTags(tags, annotations) } returns searchTags
+        every { apiService.getCount(ALIAS, USER_ID, searchTags) } returns Single.just(expected)
 
         // When
         val observer = recordService.countFhir4Records(
@@ -150,7 +141,8 @@ class RecordServiceCountRecordsTest {
             actual = result
         )
         verify(exactly = 1) { taggingService.getTagsFromType(Fhir4Resource::class.java as Class<Any>) }
-        verify(exactly = 1) { compatibilityService.countRecords(ALIAS, USER_ID, tags, annotations) }*/
+        verify(exactly = 1) { compatibilityService.resolveSearchTags(tags, annotations) }
+        verify(exactly = 1) { apiService.getCount(ALIAS, USER_ID, searchTags) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -79,7 +79,7 @@ class RecordServiceCountRecordsTest {
     @Throws(InterruptedException::class, IOException::class)
     fun `Given, countFhir3Records is called with a Fhir3Resource, a UserId and Annotations, it returns amount of occurrences`() {
         // Given
-        val expected = 42
+        /*val expected = 42
         val annotations: Annotations = mockk()
 
         every { taggingService.getTagsFromType(Fhir3Resource::class.java as Class<Any>) } returns tags
@@ -111,14 +111,14 @@ class RecordServiceCountRecordsTest {
             actual = result
         )
         verify(exactly = 1) { taggingService.getTagsFromType(Fhir3Resource::class.java as Class<Any>) }
-        verify(exactly = 1) { compatibilityService.countRecords(ALIAS, USER_ID, tags, annotations) }
+        verify(exactly = 1) { compatibilityService.countRecords(ALIAS, USER_ID, tags, annotations) }*/
     }
 
     @Test
     @Throws(InterruptedException::class, IOException::class)
     fun `Given, countFhir4Records is called with a Fhir4Resource, a UserId and Annotations, it returns amount of occurrences`() {
         // Given
-        val expected = 42
+        /*val expected = 42
         val annotations: Annotations = mockk()
 
         every { taggingService.getTagsFromType(Fhir4Resource::class.java as Class<Any>) } returns tags
@@ -150,7 +150,7 @@ class RecordServiceCountRecordsTest {
             actual = result
         )
         verify(exactly = 1) { taggingService.getTagsFromType(Fhir4Resource::class.java as Class<Any>) }
-        verify(exactly = 1) { compatibilityService.countRecords(ALIAS, USER_ID, tags, annotations) }
+        verify(exactly = 1) { compatibilityService.countRecords(ALIAS, USER_ID, tags, annotations) }*/
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsModuleTest.kt
@@ -27,6 +27,7 @@ import care.data4life.sdk.model.Record
 import care.data4life.sdk.network.NetworkingContract
 import care.data4life.sdk.network.model.EncryptedKey
 import care.data4life.sdk.network.model.EncryptedRecord
+import care.data4life.sdk.network.util.SearchTagsBuilder
 import care.data4life.sdk.record.RecordContract
 import care.data4life.sdk.tag.Annotations
 import care.data4life.sdk.tag.TagCryptoService
@@ -43,7 +44,8 @@ import care.data4life.sdk.test.util.GenericTestDataProvider.OFFSET
 import care.data4life.sdk.test.util.GenericTestDataProvider.PAGE_SIZE
 import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
 import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID
-import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID_COMPATIBILITY
+import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID_LEGACY_JS
+import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID_LEGACY_KMP
 import care.data4life.sdk.test.util.GenericTestDataProvider.UPDATE_DATE
 import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import care.data4life.sdk.test.util.TestResourceHelper
@@ -248,14 +250,11 @@ class RecordServiceFetchRecordsModuleTest {
     }
 
     private fun runBatchFlow(
-        serializedResources: Pair<String, String>,
-        encryptedRecord: EncryptedRecord,
-        encryptedLegacyRecord: EncryptedRecord,
-        searchTags: Map<String, String>,
+        serializedResources: Triple<String, String, String>,
+        encryptedRecords: List<EncryptedRecord>,
+        searchTags: String,
         encodedTags: List<String>,
         encodedAnnotations: List<String>,
-        legacyTags: List<String>,
-        legacyAnnotations: List<String>,
         tagEncryptionKeyCalls: Int,
         useStoredCommonKey: Boolean,
         commonKey: Pair<String, GCKey>,
@@ -269,16 +268,6 @@ class RecordServiceFetchRecordsModuleTest {
         pageSize: Int,
         offset: Int
     ) {
-        val (encodedSearchTags, legacySearchTags) = flowHelper.prepareCompatibilityTags(searchTags)
-
-        val encryptedTagsAndAnnotations = flowHelper.hashAndEncodeTagsAndAnnotations(
-            flowHelper.mergeTags(encodedSearchTags, encodedAnnotations)
-        )
-
-        val encryptedLegacyTagsAndAnnotations = flowHelper.hashAndEncodeTagsAndAnnotations(
-            flowHelper.mergeTags(legacySearchTags, legacyAnnotations)
-        )
-
         val encryptedCommonKey = flowHelper.prepareStoredOrUnstoredCommonKeyRun(
             alias,
             userId,
@@ -299,12 +288,12 @@ class RecordServiceFetchRecordsModuleTest {
             tagEncryptionKey = tagEncryptionKey,
             tagEncryptionKeyCalls = tagEncryptionKeyCalls,
             resources = serializedResources.toList(),
-            tags = flowHelper.mergeTags(encodedTags, legacyTags),
-            annotations = flowHelper.mergeTags(encodedAnnotations, legacyAnnotations),
+            tags = encodedTags,
+            annotations = encodedAnnotations,
             hashFunction = { value -> flowHelper.md5(value) }
         )
 
-        val search = slot<String>()
+        val search = slot<NetworkingContract.SearchTags>()
 
         (cryptoService as CryptoServiceFake).iteration = receivedIteration
 
@@ -319,31 +308,33 @@ class RecordServiceFetchRecordsModuleTest {
                 capture(search)
             )
         } answers {
-            val actual = search.captured
-            val record = when {
-                flowHelper.compareSerialisedTags(actual, encryptedTagsAndAnnotations) -> encryptedRecord
-                flowHelper.compareSerialisedTags(actual, encryptedLegacyTagsAndAnnotations) -> encryptedLegacyRecord
-                else -> throw RuntimeException(
-                    "Unexpected tags and annotations:\n$actual"
+            val actual = flowHelper.decryptSerializedTags(
+                search.captured.tags,
+                cryptoService,
+                tagEncryptionKey
+            )
+
+            if (searchTags == actual) {
+                Observable.fromCallable { encryptedRecords }
+            } else {
+                throw RuntimeException(
+                    "Unexpected tags and annotations - \nexpected: $searchTags\ngot: $actual"
                 )
             }
-
-            Observable.fromCallable { listOf(record) }
         }
     }
 
     private fun runFhirBatchFlow(
-        serializedResources: Pair<String, String>,
+        serializedResources: Triple<String, String, String>,
         tags: Tags,
-        searchTags: Map<String, String>,
         annotations: Annotations = emptyList(),
-        tagEncryptionKeyCalls: Int = 3,
+        tagEncryptionKeyCalls: Int = 4,
         useStoredCommonKey: Boolean = true,
         commonKey: Pair<String, GCKey> = COMMON_KEY_ID to this.commonKey,
         dataKey: Pair<GCKey, EncryptedKey> = this.dataKey to encryptedDataKey,
         attachmentKey: Pair<GCKey, EncryptedKey>? = this.attachmentKey to encryptedAttachmentKey,
         tagEncryptionKey: GCKey = this.tagEncryptionKey,
-        recordIds: Pair<String, String> = RECORD_ID to RECORD_ID_COMPATIBILITY,
+        recordIds: Triple<String, String, String> = Triple(RECORD_ID, RECORD_ID_LEGACY_KMP, RECORD_ID_LEGACY_JS),
         userId: String = USER_ID,
         alias: String = ALIAS,
         creationDate: String = CREATION_DATE,
@@ -353,10 +344,16 @@ class RecordServiceFetchRecordsModuleTest {
         pageSize: Int = PAGE_SIZE,
         offset: Int = OFFSET
     ) {
-        val (encodedTags, legacyTags) = flowHelper.prepareCompatibilityTags(tags)
-        val (encodedAnnotations, legacyAnnotations) = flowHelper.prepareCompatibilityAnnotations(
+        val (encodedTags, legacyKMPTags, legacyJSTags) = flowHelper.prepareCompatibilityTags(tags)
+        val (encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations) = flowHelper.prepareCompatibilityAnnotations(
             annotations
         )
+
+        val searchTags = SearchTagsBuilder.newBuilder()
+            .let { flowHelper.buildExpectedTagGroups(it, encodedTags, legacyKMPTags, legacyJSTags) }
+            .let { flowHelper.buildExpectedTagGroups(it, encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations) }
+            .seal()
+            .tags
 
         val encryptedRecord = flowHelper.prepareEncryptedFhirRecord(
             recordIds.first,
@@ -370,11 +367,23 @@ class RecordServiceFetchRecordsModuleTest {
             updateDate
         )
 
-        val encryptedLegacyRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedKMPLegacyRecord = flowHelper.prepareEncryptedFhirRecord(
             recordIds.second,
             serializedResources.second,
-            legacyTags,
-            legacyAnnotations,
+            legacyKMPTags,
+            legacyKMPAnnotations,
+            commonKey.first,
+            dataKey.second,
+            attachmentKey?.second,
+            creationDate,
+            updateDate
+        )
+
+        val encryptedJSLegacyRecord = flowHelper.prepareEncryptedFhirRecord(
+            recordIds.third,
+            serializedResources.third,
+            legacyJSTags,
+            legacyJSAnnotations,
             commonKey.first,
             dataKey.second,
             attachmentKey?.second,
@@ -384,13 +393,10 @@ class RecordServiceFetchRecordsModuleTest {
 
         runBatchFlow(
             serializedResources,
-            encryptedRecord,
-            encryptedLegacyRecord,
+            listOf(encryptedRecord, encryptedKMPLegacyRecord, encryptedJSLegacyRecord),
             searchTags,
-            encodedTags,
-            encodedAnnotations,
-            legacyTags,
-            legacyAnnotations,
+            flowHelper.mergeTags(encodedTags, legacyKMPTags, legacyJSTags),
+            flowHelper.mergeTags(encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations),
             tagEncryptionKeyCalls,
             useStoredCommonKey,
             commonKey,
@@ -407,17 +413,16 @@ class RecordServiceFetchRecordsModuleTest {
     }
 
     private fun runDataBatchFlow(
-        serializedResources: Pair<String, String>,
+        serializedResources: Triple<String, String, String>,
         tags: Tags,
-        searchTags: Map<String, String>,
         annotations: Annotations = emptyList(),
-        tagEncryptionKeyCalls: Int = 3,
+        tagEncryptionKeyCalls: Int = 4,
         useStoredCommonKey: Boolean = true,
         commonKey: Pair<String, GCKey> = COMMON_KEY_ID to this.commonKey,
         dataKey: Pair<GCKey, EncryptedKey> = this.dataKey to encryptedDataKey,
         attachmentKey: Pair<GCKey, EncryptedKey>? = this.attachmentKey to encryptedAttachmentKey,
         tagEncryptionKey: GCKey = this.tagEncryptionKey,
-        recordIds: Pair<String, String> = RECORD_ID to RECORD_ID_COMPATIBILITY,
+        recordIds: Triple<String, String, String> = Triple(RECORD_ID, RECORD_ID_LEGACY_KMP, RECORD_ID_LEGACY_JS),
         userId: String = USER_ID,
         alias: String = ALIAS,
         creationDate: String = CREATION_DATE,
@@ -427,10 +432,15 @@ class RecordServiceFetchRecordsModuleTest {
         pageSize: Int = PAGE_SIZE,
         offset: Int = OFFSET
     ) {
-        val (encodedTags, legacyTags) = flowHelper.prepareCompatibilityTags(tags)
-        val (encodedAnnotations, legacyAnnotations) = flowHelper.prepareCompatibilityAnnotations(
+        val (encodedTags, legacyKMPTags, legacyJSTags) = flowHelper.prepareCompatibilityTags(tags)
+        val (encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations) = flowHelper.prepareCompatibilityAnnotations(
             annotations
         )
+        val searchTags = SearchTagsBuilder.newBuilder()
+            .let { flowHelper.buildExpectedTagGroups(it, encodedTags, legacyKMPTags, legacyJSTags) }
+            .let { flowHelper.buildExpectedTagGroups(it, encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations) }
+            .seal()
+            .tags
 
         val encryptedRecord = flowHelper.prepareEncryptedDataRecord(
             recordIds.first,
@@ -444,11 +454,23 @@ class RecordServiceFetchRecordsModuleTest {
             updateDate
         )
 
-        val encryptedLegacyRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedKMPLegacyRecord = flowHelper.prepareEncryptedDataRecord(
             recordIds.second,
             serializedResources.second,
-            legacyTags,
-            legacyAnnotations,
+            legacyKMPTags,
+            legacyKMPAnnotations,
+            commonKey.first,
+            dataKey.second,
+            attachmentKey?.second,
+            creationDate,
+            updateDate
+        )
+
+        val encryptedJSLegacyRecord = flowHelper.prepareEncryptedDataRecord(
+            recordIds.third,
+            serializedResources.third,
+            legacyJSTags,
+            legacyJSAnnotations,
             commonKey.first,
             dataKey.second,
             attachmentKey?.second,
@@ -458,13 +480,10 @@ class RecordServiceFetchRecordsModuleTest {
 
         runBatchFlow(
             serializedResources,
-            encryptedRecord,
-            encryptedLegacyRecord,
+            listOf(encryptedRecord, encryptedKMPLegacyRecord, encryptedJSLegacyRecord),
             searchTags,
-            encodedTags,
-            encodedAnnotations,
-            legacyTags,
-            legacyAnnotations,
+            flowHelper.mergeTags(encodedTags, legacyKMPTags, legacyJSTags),
+            flowHelper.mergeTags(encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations),
             tagEncryptionKeyCalls,
             useStoredCommonKey,
             commonKey,
@@ -792,11 +811,6 @@ class RecordServiceFetchRecordsModuleTest {
             "resourcetype" to resourceType
         )
 
-        val searchTags = mapOf(
-            "fhirversion" to "3.0.1",
-            "resourcetype" to resourceType
-        )
-
         val template = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
@@ -807,7 +821,14 @@ class RecordServiceFetchRecordsModuleTest {
         val template2 = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
-            RECORD_ID_COMPATIBILITY,
+            RECORD_ID_LEGACY_KMP,
+            PARTNER_ID
+        )
+
+        val template3 = TestResourceHelper.loadTemplate(
+            "common",
+            "documentReference-without-attachment-template",
+            RECORD_ID_LEGACY_JS,
             PARTNER_ID
         )
 
@@ -816,19 +837,26 @@ class RecordServiceFetchRecordsModuleTest {
             template
         ) as Fhir3DocumentReference
 
-        val legacyResource = SdkFhirParser.toFhir3(
+        val legacyKMPResource = SdkFhirParser.toFhir3(
             resourceType,
             template2
         ) as Fhir3DocumentReference
 
-        legacyResource.description = "legacyRecord"
+        val legacyJSResource = SdkFhirParser.toFhir3(
+            resourceType,
+            template3
+        ) as Fhir3DocumentReference
+
+        legacyKMPResource.description = "legacyKMPRecord"
+        legacyJSResource.description = "legacyKMPRecord"
 
         runFhirBatchFlow(
-            serializedResources = SdkFhirParser.fromResource(resource)!! to SdkFhirParser.fromResource(
-                legacyResource
-            )!!,
+            serializedResources = Triple(
+                SdkFhirParser.fromResource(resource)!!,
+                SdkFhirParser.fromResource(legacyKMPResource)!!,
+                SdkFhirParser.fromResource(legacyJSResource)!!
+            ),
             tags = tags,
-            searchTags = searchTags,
             useStoredCommonKey = false
         )
 
@@ -845,7 +873,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -854,10 +882,15 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = SdkFhirParser.fromResource(result[1].resource),
-            expected = SdkFhirParser.fromResource(legacyResource)
+            expected = SdkFhirParser.fromResource(legacyKMPResource)
+        )
+        assertEquals(
+            actual = SdkFhirParser.fromResource(result[2].resource),
+            expected = SdkFhirParser.fromResource(legacyJSResource)
         )
         assertTrue(result[0].annotations.isNullOrEmpty())
         assertTrue(result[1].annotations.isNullOrEmpty())
+        assertTrue(result[2].annotations.isNullOrEmpty())
     }
 
     @Test
@@ -867,11 +900,6 @@ class RecordServiceFetchRecordsModuleTest {
         val tags = mapOf(
             "partner" to PARTNER_ID,
             "client" to CLIENT_ID,
-            "fhirversion" to "3.0.1",
-            "resourcetype" to resourceType
-        )
-
-        val searchTags = mapOf(
             "fhirversion" to "3.0.1",
             "resourcetype" to resourceType
         )
@@ -894,7 +922,14 @@ class RecordServiceFetchRecordsModuleTest {
         val template2 = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
-            RECORD_ID_COMPATIBILITY,
+            RECORD_ID_LEGACY_KMP,
+            PARTNER_ID
+        )
+
+        val template3 = TestResourceHelper.loadTemplate(
+            "common",
+            "documentReference-without-attachment-template",
+            RECORD_ID_LEGACY_JS,
             PARTNER_ID
         )
 
@@ -903,20 +938,27 @@ class RecordServiceFetchRecordsModuleTest {
             template
         ) as Fhir3DocumentReference
 
-        val legacyResource = SdkFhirParser.toFhir3(
+        val legacyKMPResource = SdkFhirParser.toFhir3(
             resourceType,
             template2
         ) as Fhir3DocumentReference
 
-        legacyResource.description = "legacyRecord"
+        val legacyJSResource = SdkFhirParser.toFhir3(
+            resourceType,
+            template3
+        ) as Fhir3DocumentReference
+
+        legacyKMPResource.description = "legacyRecord"
+        legacyJSResource.description = "legacyRecord"
 
         runFhirBatchFlow(
-            serializedResources = SdkFhirParser.fromResource(resource)!! to SdkFhirParser.fromResource(
-                legacyResource
-            )!!,
+            serializedResources = Triple(
+                SdkFhirParser.fromResource(resource)!!,
+                SdkFhirParser.fromResource(legacyKMPResource)!!,
+                SdkFhirParser.fromResource(legacyJSResource)!!
+            ),
             tags = tags,
-            annotations = annotations,
-            searchTags = searchTags
+            annotations = annotations
         )
 
         // When
@@ -932,7 +974,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -941,7 +983,11 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = SdkFhirParser.fromResource(result[1].resource),
-            expected = SdkFhirParser.fromResource(legacyResource)
+            expected = SdkFhirParser.fromResource(legacyKMPResource)
+        )
+        assertEquals(
+            actual = SdkFhirParser.fromResource(result[2].resource),
+            expected = SdkFhirParser.fromResource(legacyJSResource)
         )
         assertEquals(
             actual = result[0].annotations,
@@ -949,6 +995,10 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = result[1].annotations,
+            expected = annotations
+        )
+        assertEquals(
+            actual = result[2].annotations,
             expected = annotations
         )
     }
@@ -960,11 +1010,6 @@ class RecordServiceFetchRecordsModuleTest {
         val tags = mapOf(
             "partner" to PARTNER_ID,
             "client" to CLIENT_ID,
-            "fhirversion" to "3.0.1",
-            "resourcetype" to resourceType
-        )
-
-        val searchTags = mapOf(
             "fhirversion" to "3.0.1",
             "resourcetype" to resourceType
         )
@@ -990,7 +1035,14 @@ class RecordServiceFetchRecordsModuleTest {
         val template2 = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
-            RECORD_ID_COMPATIBILITY,
+            RECORD_ID_LEGACY_KMP,
+            PARTNER_ID
+        )
+
+        val template3 = TestResourceHelper.loadTemplate(
+            "common",
+            "documentReference-without-attachment-template",
+            RECORD_ID_LEGACY_JS,
             PARTNER_ID
         )
 
@@ -999,20 +1051,27 @@ class RecordServiceFetchRecordsModuleTest {
             template
         ) as Fhir3DocumentReference
 
-        val legacyResource = SdkFhirParser.toFhir3(
+        val legacyKMPResource = SdkFhirParser.toFhir3(
             resourceType,
             template2
         ) as Fhir3DocumentReference
 
-        legacyResource.description = "legacyRecord"
+        val legacyJSResource = SdkFhirParser.toFhir3(
+            resourceType,
+            template3
+        ) as Fhir3DocumentReference
+
+        legacyKMPResource.description = "legacyRecord"
+        legacyJSResource.description = "legacyRecord"
 
         runFhirBatchFlow(
-            serializedResources = SdkFhirParser.fromResource(resource)!! to SdkFhirParser.fromResource(
-                legacyResource
-            )!!,
+            serializedResources = Triple(
+                SdkFhirParser.fromResource(resource)!!,
+                SdkFhirParser.fromResource(legacyKMPResource)!!,
+                SdkFhirParser.fromResource(legacyJSResource)!!,
+            ),
             tags = tags,
             annotations = annotations,
-            searchTags = searchTags,
             startDate = startDate.toString(),
             endDate = endDate.toString()
         )
@@ -1030,7 +1089,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -1039,7 +1098,11 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = SdkFhirParser.fromResource(result[1].resource),
-            expected = SdkFhirParser.fromResource(legacyResource)
+            expected = SdkFhirParser.fromResource(legacyKMPResource)
+        )
+        assertEquals(
+            actual = SdkFhirParser.fromResource(result[2].resource),
+            expected = SdkFhirParser.fromResource(legacyJSResource)
         )
         assertEquals(
             actual = result[0].annotations,
@@ -1047,6 +1110,11 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = result[1].annotations,
+            expected = annotations
+        )
+
+        assertEquals(
+            actual = result[2].annotations,
             expected = annotations
         )
     }
@@ -1063,11 +1131,6 @@ class RecordServiceFetchRecordsModuleTest {
             "resourcetype" to resourceType
         )
 
-        val searchTags = mapOf(
-            "fhirversion" to "4.0.1",
-            "resourcetype" to resourceType
-        )
-
         val template = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
@@ -1078,7 +1141,14 @@ class RecordServiceFetchRecordsModuleTest {
         val template2 = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
-            RECORD_ID_COMPATIBILITY,
+            RECORD_ID_LEGACY_KMP,
+            PARTNER_ID
+        )
+
+        val template3 = TestResourceHelper.loadTemplate(
+            "common",
+            "documentReference-without-attachment-template",
+            RECORD_ID_LEGACY_JS,
             PARTNER_ID
         )
 
@@ -1087,19 +1157,26 @@ class RecordServiceFetchRecordsModuleTest {
             template
         ) as Fhir4DocumentReference
 
-        val legacyResource = SdkFhirParser.toFhir4(
+        val legacyKMPResource = SdkFhirParser.toFhir4(
             resourceType,
             template2
         ) as Fhir4DocumentReference
 
-        legacyResource.description = "legacyRecord"
+        val legacyJSResource = SdkFhirParser.toFhir4(
+            resourceType,
+            template3
+        ) as Fhir4DocumentReference
+
+        legacyKMPResource.description = "legacyKMPRecord"
+        legacyJSResource.description = "legacyJSRecord"
 
         runFhirBatchFlow(
-            serializedResources = SdkFhirParser.fromResource(resource)!! to SdkFhirParser.fromResource(
-                legacyResource
-            )!!,
+            serializedResources = Triple(
+                SdkFhirParser.fromResource(resource)!!,
+                SdkFhirParser.fromResource(legacyKMPResource)!!,
+                SdkFhirParser.fromResource(legacyJSResource)!!
+            ),
             tags = tags,
-            searchTags = searchTags,
             useStoredCommonKey = false
         )
 
@@ -1116,7 +1193,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -1125,10 +1202,15 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = SdkFhirParser.fromResource(result[1].resource),
-            expected = SdkFhirParser.fromResource(legacyResource)
+            expected = SdkFhirParser.fromResource(legacyKMPResource)
+        )
+        assertEquals(
+            actual = SdkFhirParser.fromResource(result[2].resource),
+            expected = SdkFhirParser.fromResource(legacyJSResource)
         )
         assertTrue(result[0].annotations.isNullOrEmpty())
         assertTrue(result[1].annotations.isNullOrEmpty())
+        assertTrue(result[2].annotations.isNullOrEmpty())
     }
 
     @Test
@@ -1138,11 +1220,6 @@ class RecordServiceFetchRecordsModuleTest {
         val tags = mapOf(
             "partner" to PARTNER_ID,
             "client" to CLIENT_ID,
-            "fhirversion" to "4.0.1",
-            "resourcetype" to resourceType
-        )
-
-        val searchTags = mapOf(
             "fhirversion" to "4.0.1",
             "resourcetype" to resourceType
         )
@@ -1165,7 +1242,14 @@ class RecordServiceFetchRecordsModuleTest {
         val template2 = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
-            RECORD_ID_COMPATIBILITY,
+            RECORD_ID_LEGACY_KMP,
+            PARTNER_ID
+        )
+
+        val template3 = TestResourceHelper.loadTemplate(
+            "common",
+            "documentReference-without-attachment-template",
+            RECORD_ID_LEGACY_JS,
             PARTNER_ID
         )
 
@@ -1174,20 +1258,27 @@ class RecordServiceFetchRecordsModuleTest {
             template
         ) as Fhir4DocumentReference
 
-        val legacyResource = SdkFhirParser.toFhir4(
+        val legacyKMPResource = SdkFhirParser.toFhir4(
             resourceType,
             template2
         ) as Fhir4DocumentReference
 
-        legacyResource.description = "legacyRecord"
+        val legacyJSResource = SdkFhirParser.toFhir4(
+            resourceType,
+            template3
+        ) as Fhir4DocumentReference
+
+        legacyKMPResource.description = "legacyKMPRecord"
+        legacyJSResource.description = "legacyJSRecord"
 
         runFhirBatchFlow(
-            serializedResources = SdkFhirParser.fromResource(resource)!! to SdkFhirParser.fromResource(
-                legacyResource
-            )!!,
+            serializedResources = Triple(
+                SdkFhirParser.fromResource(resource)!!,
+                SdkFhirParser.fromResource(legacyKMPResource)!!,
+                SdkFhirParser.fromResource(legacyJSResource)!!
+            ),
             tags = tags,
-            annotations = annotations,
-            searchTags = searchTags
+            annotations = annotations
         )
 
         // When
@@ -1203,7 +1294,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -1212,7 +1303,11 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = SdkFhirParser.fromResource(result[1].resource),
-            expected = SdkFhirParser.fromResource(legacyResource)
+            expected = SdkFhirParser.fromResource(legacyKMPResource)
+        )
+        assertEquals(
+            actual = SdkFhirParser.fromResource(result[2].resource),
+            expected = SdkFhirParser.fromResource(legacyJSResource)
         )
         assertEquals(
             actual = result[0].annotations,
@@ -1220,6 +1315,10 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = result[1].annotations,
+            expected = annotations
+        )
+        assertEquals(
+            actual = result[2].annotations,
             expected = annotations
         )
     }
@@ -1235,11 +1334,6 @@ class RecordServiceFetchRecordsModuleTest {
             "resourcetype" to resourceType
         )
 
-        val searchTags = mapOf(
-            "fhirversion" to "4.0.1",
-            "resourcetype" to resourceType
-        )
-
         val annotations = listOf(
             "wow",
             "it",
@@ -1261,7 +1355,14 @@ class RecordServiceFetchRecordsModuleTest {
         val template2 = TestResourceHelper.loadTemplate(
             "common",
             "documentReference-without-attachment-template",
-            RECORD_ID_COMPATIBILITY,
+            RECORD_ID_LEGACY_KMP,
+            PARTNER_ID
+        )
+
+        val template3 = TestResourceHelper.loadTemplate(
+            "common",
+            "documentReference-without-attachment-template",
+            RECORD_ID_LEGACY_JS,
             PARTNER_ID
         )
 
@@ -1270,20 +1371,27 @@ class RecordServiceFetchRecordsModuleTest {
             template
         ) as Fhir4DocumentReference
 
-        val legacyResource = SdkFhirParser.toFhir4(
+        val legacyKMPResource = SdkFhirParser.toFhir4(
             resourceType,
             template2
         ) as Fhir4DocumentReference
 
-        legacyResource.description = "legacyRecord"
+        val legacyJSResource = SdkFhirParser.toFhir4(
+            resourceType,
+            template3
+        ) as Fhir4DocumentReference
+
+        legacyKMPResource.description = "legacyKMPRecord"
+        legacyJSResource.description = "legacyJSRecord"
 
         runFhirBatchFlow(
-            serializedResources = SdkFhirParser.fromResource(resource)!! to SdkFhirParser.fromResource(
-                legacyResource
-            )!!,
+            serializedResources = Triple(
+                SdkFhirParser.fromResource(resource)!!,
+                SdkFhirParser.fromResource(legacyKMPResource)!!,
+                SdkFhirParser.fromResource(legacyJSResource)!!,
+            ),
             tags = tags,
             annotations = annotations,
-            searchTags = searchTags,
             startDate = startDate.toString(),
             endDate = endDate.toString()
         )
@@ -1301,7 +1409,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -1310,7 +1418,11 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = SdkFhirParser.fromResource(result[1].resource),
-            expected = SdkFhirParser.fromResource(legacyResource)
+            expected = SdkFhirParser.fromResource(legacyKMPResource)
+        )
+        assertEquals(
+            actual = SdkFhirParser.fromResource(result[2].resource),
+            expected = SdkFhirParser.fromResource(legacyJSResource)
         )
         assertEquals(
             actual = result[0].annotations,
@@ -1318,6 +1430,10 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = result[1].annotations,
+            expected = annotations
+        )
+        assertEquals(
+            actual = result[2].annotations,
             expected = annotations
         )
     }
@@ -1333,14 +1449,9 @@ class RecordServiceFetchRecordsModuleTest {
             "client" to CLIENT_ID
         )
 
-        val searchTags = mapOf(
-            "flag" to ARBITRARY_DATA_KEY
-        )
-
         runDataBatchFlow(
-            serializedResources = resource to resource,
+            serializedResources = Triple(resource, resource, resource),
             tags = tags,
-            searchTags = searchTags,
             useStoredCommonKey = false
         )
 
@@ -1356,30 +1467,38 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 1,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
             actual = String(result[0].resource.value),
             expected = resource
         )
+        assertEquals(
+            actual = String(result[1].resource.value),
+            expected = resource
+        )
+        assertEquals(
+            actual = String(result[2].resource.value),
+            expected = resource
+        )
+
         assertTrue(result[0].annotations.isNullOrEmpty())
+        assertTrue(result[1].annotations.isNullOrEmpty())
+        assertTrue(result[2].annotations.isNullOrEmpty())
     }
 
     @Test
     fun `Given, fetchDataRecords is called, with its appropriate payloads, it returns a List of Records filtered by Annotations`() {
         // Given
         val resource = "The never ending story."
-        val legacyResource = "Completely new design, ey."
+        val legacyKMPResource = "Completely new design, ey."
+        val legacyJSResource = "And another bug, ey."
 
         val tags = mapOf(
             "flag" to ARBITRARY_DATA_KEY,
             "partner" to PARTNER_ID,
             "client" to CLIENT_ID
-        )
-
-        val searchTags = mapOf(
-            "flag" to ARBITRARY_DATA_KEY
         )
 
         val annotations = listOf(
@@ -1391,10 +1510,9 @@ class RecordServiceFetchRecordsModuleTest {
         )
 
         runDataBatchFlow(
-            serializedResources = resource to legacyResource,
+            serializedResources = Triple(resource, legacyKMPResource, legacyJSResource),
             tags = tags,
-            annotations = annotations,
-            searchTags = searchTags
+            annotations = annotations
         )
 
         // When
@@ -1409,7 +1527,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -1418,7 +1536,11 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = String(result[1].resource.value),
-            expected = legacyResource
+            expected = legacyKMPResource
+        )
+        assertEquals(
+            actual = String(result[2].resource.value),
+            expected = legacyJSResource
         )
         assertEquals(
             actual = result[0].annotations,
@@ -1428,22 +1550,23 @@ class RecordServiceFetchRecordsModuleTest {
             actual = result[1].annotations,
             expected = annotations
         )
+        assertEquals(
+            actual = result[2].annotations,
+            expected = annotations
+        )
     }
 
     @Test
     fun `Given, fetchDataRecords is called, with its appropriate payloads, it returns a List of Records filtered by the provided date parameter and Annotations`() {
         // Given
         val resource = "The never ending story."
-        val legacyResource = "Completely new design, ey."
+        val legacyKMPResource = "Completely new design, ey."
+        val legacyJSResource = "And another bug, ey."
 
         val tags = mapOf(
             "flag" to ARBITRARY_DATA_KEY,
             "partner" to PARTNER_ID,
             "client" to CLIENT_ID
-        )
-
-        val searchTags = mapOf(
-            "flag" to ARBITRARY_DATA_KEY
         )
 
         val annotations = listOf(
@@ -1458,10 +1581,9 @@ class RecordServiceFetchRecordsModuleTest {
         val endDate = LocalDate.of(2020, 12, 1)
 
         runDataBatchFlow(
-            serializedResources = resource to legacyResource,
+            serializedResources = Triple(resource, legacyKMPResource, legacyJSResource),
             tags = tags,
             annotations = annotations,
-            searchTags = searchTags,
             startDate = startDate.toString(),
             endDate = endDate.toString()
         )
@@ -1478,7 +1600,7 @@ class RecordServiceFetchRecordsModuleTest {
 
         // Then
         assertEquals(
-            expected = 2,
+            expected = 3,
             actual = result.size
         )
         assertEquals(
@@ -1487,7 +1609,11 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = String(result[1].resource.value),
-            expected = legacyResource
+            expected = legacyKMPResource
+        )
+        assertEquals(
+            actual = String(result[2].resource.value),
+            expected = legacyJSResource
         )
         assertEquals(
             actual = result[0].annotations,
@@ -1495,6 +1621,10 @@ class RecordServiceFetchRecordsModuleTest {
         )
         assertEquals(
             actual = result[1].annotations,
+            expected = annotations
+        )
+        assertEquals(
+            actual = result[2].annotations,
             expected = annotations
         )
     }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
@@ -317,7 +317,7 @@ class RecordServiceFetchRecordsTest {
     @Test
     fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it returns List of Records`() {
         // Given
-        mockkObject(SdkDateTimeFormatter)
+        /*mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir3CarePlan = mockk()
         val id1 = "id1"
@@ -434,13 +434,13 @@ class RecordServiceFetchRecordsTest {
         }
         verify(exactly = 0) { SdkDateTimeFormatter.formatDate(any()) }
 
-        unmockkObject(SdkDateTimeFormatter)
+        unmockkObject(SdkDateTimeFormatter)*/
     }
 
     @Test
     fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize and Offset, it returns List of Records`() {
         // Given
-        mockkObject(SdkDateTimeFormatter)
+        /*mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir3CarePlan = mockk()
         val id1 = "id1"
@@ -566,13 +566,13 @@ class RecordServiceFetchRecordsTest {
             RecordMapper.getInstance(decryptedRecord2)
         }
 
-        unmockkObject(SdkDateTimeFormatter)
+        unmockkObject(SdkDateTimeFormatter)*/
     }
 
     @Test
     fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it returns List of Fhir4Records`() {
         // Given
-        mockkObject(SdkDateTimeFormatter)
+        /*mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir4CarePlan = mockk()
         val id1 = "id1"
@@ -681,13 +681,13 @@ class RecordServiceFetchRecordsTest {
         }
         verify(exactly = 0) { SdkDateTimeFormatter.formatDate(any()) }
 
-        unmockkObject(SdkDateTimeFormatter)
+        unmockkObject(SdkDateTimeFormatter)*/
     }
 
     @Test
     fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize and Offset, it returns List of Fhir4Records`() {
         // Given
-        mockkObject(SdkDateTimeFormatter)
+        /*mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir4CarePlan = mockk()
         val id1 = "id1"
@@ -814,6 +814,6 @@ class RecordServiceFetchRecordsTest {
             RecordMapper.getInstance(decryptedRecord2)
         }
 
-        unmockkObject(SdkDateTimeFormatter)
+        unmockkObject(SdkDateTimeFormatter)*/
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsTest.kt
@@ -317,7 +317,7 @@ class RecordServiceFetchRecordsTest {
     @Test
     fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it returns List of Records`() {
         // Given
-        /*mockkObject(SdkDateTimeFormatter)
+        mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir3CarePlan = mockk()
         val id1 = "id1"
@@ -332,6 +332,7 @@ class RecordServiceFetchRecordsTest {
         val offset = 42
         val pageSize = 23
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val searchTags: NetworkingContract.SearchTags = mockk()
 
         every {
             hint(Fhir3CarePlan::class)
@@ -347,16 +348,17 @@ class RecordServiceFetchRecordsTest {
         every { decryptedRecord2.annotations } returns defaultAnnotation
 
         every { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { compatibilityService.resolveSearchTags(tags, defaultAnnotation) } returns searchTags
+
         every {
-            compatibilityService.searchRecords(
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 null,
                 null,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
         } returns Observable.fromArray(encryptedRecords)
         every {
@@ -409,15 +411,15 @@ class RecordServiceFetchRecordsTest {
                 offset
             )
             taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>)
-            compatibilityService.searchRecords(
+            compatibilityService.resolveSearchTags(tags, defaultAnnotation)
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 null,
                 null,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
             recordService.decryptRecord<Fhir3CarePlan>(
                 encryptedRecord1,
@@ -434,13 +436,13 @@ class RecordServiceFetchRecordsTest {
         }
         verify(exactly = 0) { SdkDateTimeFormatter.formatDate(any()) }
 
-        unmockkObject(SdkDateTimeFormatter)*/
+        unmockkObject(SdkDateTimeFormatter)
     }
 
     @Test
     fun `Given, fetchFhir3Records called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize and Offset, it returns List of Records`() {
         // Given
-        /*mockkObject(SdkDateTimeFormatter)
+        mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir3CarePlan = mockk()
         val id1 = "id1"
@@ -459,6 +461,7 @@ class RecordServiceFetchRecordsTest {
         val offset = 42
         val pageSize = 23
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val searchTags: NetworkingContract.SearchTags = mockk()
 
         every {
             hint(Fhir3CarePlan::class)
@@ -476,17 +479,19 @@ class RecordServiceFetchRecordsTest {
 
         every { SdkDateTimeFormatter.formatDate(startDate) } returns start
         every { SdkDateTimeFormatter.formatDate(endDate) } returns end
+
         every { taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>) } returns tags
+        every { compatibilityService.resolveSearchTags(tags, defaultAnnotation) } returns searchTags
+
         every {
-            compatibilityService.searchRecords(
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 start,
                 end,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
         } returns Observable.fromArray(encryptedRecords)
 
@@ -542,15 +547,15 @@ class RecordServiceFetchRecordsTest {
             SdkDateTimeFormatter.formatDate(startDate)
             SdkDateTimeFormatter.formatDate(endDate)
             taggingService.getTagsFromType(Fhir3CarePlan::class.java as Class<Any>)
-            compatibilityService.searchRecords(
+            compatibilityService.resolveSearchTags(tags, defaultAnnotation)
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 start,
                 end,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
             recordService.decryptRecord<Fhir3CarePlan>(
                 encryptedRecord1,
@@ -566,13 +571,13 @@ class RecordServiceFetchRecordsTest {
             RecordMapper.getInstance(decryptedRecord2)
         }
 
-        unmockkObject(SdkDateTimeFormatter)*/
+        unmockkObject(SdkDateTimeFormatter)
     }
 
     @Test
     fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a nulled StartDate, a nulled EndDate, the PageSize and Offset, it returns List of Fhir4Records`() {
         // Given
-        /*mockkObject(SdkDateTimeFormatter)
+        mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir4CarePlan = mockk()
         val id1 = "id1"
@@ -587,6 +592,7 @@ class RecordServiceFetchRecordsTest {
         val offset = 42
         val pageSize = 23
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val searchTags: NetworkingContract.SearchTags = mockk()
 
         every {
             hint(Fhir4CarePlan::class)
@@ -600,16 +606,17 @@ class RecordServiceFetchRecordsTest {
         every { decryptedRecord2.identifier } returns id2
 
         every { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { compatibilityService.resolveSearchTags(tags, defaultAnnotation) } returns searchTags
+
         every {
-            compatibilityService.searchRecords(
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 null,
                 null,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
         } returns Observable.fromArray(encryptedRecords)
         every { decryptedRecord1.annotations } returns defaultAnnotation
@@ -656,15 +663,15 @@ class RecordServiceFetchRecordsTest {
 
         verifyOrder {
             taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>)
-            compatibilityService.searchRecords(
+            compatibilityService.resolveSearchTags(tags, defaultAnnotation)
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 null,
                 null,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
             recordService.decryptRecord<Fhir4CarePlan>(
                 encryptedRecord1,
@@ -681,13 +688,13 @@ class RecordServiceFetchRecordsTest {
         }
         verify(exactly = 0) { SdkDateTimeFormatter.formatDate(any()) }
 
-        unmockkObject(SdkDateTimeFormatter)*/
+        unmockkObject(SdkDateTimeFormatter)
     }
 
     @Test
     fun `Given, fetchFhir4Records called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize and Offset, it returns List of Fhir4Records`() {
         // Given
-        /*mockkObject(SdkDateTimeFormatter)
+        mockkObject(SdkDateTimeFormatter)
 
         val resource1: Fhir4CarePlan = mockk()
         val id1 = "id1"
@@ -706,6 +713,7 @@ class RecordServiceFetchRecordsTest {
         val offset = 42
         val pageSize = 23
         val encryptedRecords = listOf(encryptedRecord1, encryptedRecord2)
+        val searchTags: NetworkingContract.SearchTags = mockk()
 
         every {
             hint(Fhir4CarePlan::class)
@@ -723,17 +731,19 @@ class RecordServiceFetchRecordsTest {
 
         every { SdkDateTimeFormatter.formatDate(startDate) } returns start
         every { SdkDateTimeFormatter.formatDate(endDate) } returns end
+
         every { taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>) } returns tags
+        every { compatibilityService.resolveSearchTags(tags, defaultAnnotation) } returns searchTags
+
         every {
-            compatibilityService.searchRecords(
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 start,
                 end,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
         } returns Observable.fromArray(encryptedRecords)
 
@@ -790,15 +800,15 @@ class RecordServiceFetchRecordsTest {
             SdkDateTimeFormatter.formatDate(startDate)
             SdkDateTimeFormatter.formatDate(endDate)
             taggingService.getTagsFromType(Fhir4CarePlan::class.java as Class<Any>)
-            compatibilityService.searchRecords(
+            compatibilityService.resolveSearchTags(tags, defaultAnnotation)
+            apiService.searchRecords(
                 ALIAS,
                 USER_ID,
                 start,
                 end,
                 pageSize,
                 offset,
-                tags,
-                defaultAnnotation
+                searchTags
             )
             recordService.decryptRecord<Fhir4CarePlan>(
                 encryptedRecord1,
@@ -814,6 +824,6 @@ class RecordServiceFetchRecordsTest {
             RecordMapper.getInstance(decryptedRecord2)
         }
 
-        unmockkObject(SdkDateTimeFormatter)*/
+        unmockkObject(SdkDateTimeFormatter)
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceModuleTestFlowHelper.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceModuleTestFlowHelper.kt
@@ -90,14 +90,17 @@ class RecordServiceModuleTestFlowHelper(
         tags.forEach { (key, value) ->
             encodedTags.add("${key.toLowerCase()}=${JSLegacyTagConverter.convertTag(encode(value))}")
         }
+
         return encodedTags
     }
+
     fun prepareCompatibilityTags(
         tags: Tags
     ): Triple<List<String>, List<String>, List<String>> {
         val encodedTags = prepareTags(tags)
         val androidLegacyTag = tags.map { (key, value) -> prepareAndroidLegacyTag(key, value) }
         val jsLegacyTags = prepareJSLegacyTags(tags)
+
         return Triple(encodedTags, androidLegacyTag, jsLegacyTags)
     }
 
@@ -119,6 +122,7 @@ class RecordServiceModuleTestFlowHelper(
         val encodedAnnotations = prepareAnnotations(annotations)
         val legacyAndroidAnnotations = prepareAndroidLegacyAnnotations(annotations)
         val legacyJSAnnotations = prepareJSLegacyAnnotations(annotations)
+
         return Triple(encodedAnnotations, legacyAndroidAnnotations, legacyJSAnnotations)
     }
 
@@ -151,6 +155,7 @@ class RecordServiceModuleTestFlowHelper(
                 )
             }
         }
+
         return builder
     }
 
@@ -162,7 +167,9 @@ class RecordServiceModuleTestFlowHelper(
         val unOrderedTags = tags.replace("(", "")
             .replace(")", "")
             .split(",")
+
         val mappedTags = mutableMapOf<String, String>()
+
         unOrderedTags.forEach { tag ->
             Base64.decode(tag)
                 .let { encrypted ->
@@ -175,6 +182,7 @@ class RecordServiceModuleTestFlowHelper(
                 .let { decrypted -> String(decrypted, StandardCharsets.UTF_8) }
                 .also { mappedTags[tag] = it }
         }
+
         return mappedTags
     }
 
@@ -188,20 +196,28 @@ class RecordServiceModuleTestFlowHelper(
         mappedTags.forEach { tag ->
             plain = plain.replace(tag.key, tag.value)
         }
+
         return plain
     }
+
+    fun hashAndEncodeTagsAndAnnotations(
+        tagsAndAnnotations: List<String>
+    ): List<String> = tagsAndAnnotations.map { Base64.encodeToString(md5(it)) }
 
     fun mapAttachments(
         payload: ByteArray,
         resized: Pair<Pair<ByteArray, String>, Pair<ByteArray, String>?>? = null
     ): List<String> {
         val attachments = mutableListOf(String(payload))
+
         if (resized is Pair<*, *>) {
             attachments.add(String(resized.first.first))
+
             if (resized.second is Pair<*, *>) {
                 attachments.add(String(resized.second!!.first))
             }
         }
+
         return attachments
     }
 
@@ -212,6 +228,7 @@ class RecordServiceModuleTestFlowHelper(
         resized: Pair<Pair<ByteArray, String>, Pair<ByteArray, String>?>? = null
     ) {
         resizing(payload.first, resized)
+
         fakeUpload(
             userId,
             alias,
@@ -228,10 +245,12 @@ class RecordServiceModuleTestFlowHelper(
     ) {
         val sendAttachment = slot<ByteArray>()
         val (data, ids) = resolveUploadData(payload, resized)
+
         every {
             apiService.uploadDocument(alias, userId, capture(sendAttachment))
         } answers {
             val idx = data.indexOf(String(sendAttachment.captured))
+
             if (idx >= 0) {
                 Single.just(ids[idx])
             } else {
@@ -246,14 +265,17 @@ class RecordServiceModuleTestFlowHelper(
     ): Pair<List<String>, List<String>> {
         val ids = mutableListOf(payload.second)
         val data = mutableListOf(md5(String(payload.first)))
+
         if (resized is Pair<*, *>) {
             ids.add(resized.first.second)
             data.add(md5(String(resized.first.first)))
+
             if (resized.second is Pair<*, *>) {
                 ids.add(resized.second!!.second)
                 data.add(md5(String(resized.second!!.first)))
             }
         }
+
         return Pair(data, ids)
     }
 
@@ -265,11 +287,13 @@ class RecordServiceModuleTestFlowHelper(
             every { imageResizer.isResizable(data) } returns false
         } else {
             every { imageResizer.isResizable(data) } returns true
+
             resizeImage(
                 data,
                 resizedImages.first.first,
                 DEFAULT_PREVIEW_SIZE_PX
             )
+
             if (resizedImages.second is Pair<*, *>) {
                 resizeImage(
                     data,
@@ -330,10 +354,12 @@ class RecordServiceModuleTestFlowHelper(
     ): EncryptedKey {
         val commonKeyResponse: CommonKeyResponse = mockk()
         val encryptedCommonKey: EncryptedKey = mockk()
+
         every {
             apiService.fetchCommonKey(alias, userId, commonKeyId)
         } returns Single.just(commonKeyResponse)
         every { commonKeyResponse.commonKey } returns encryptedCommonKey
+
         return encryptedCommonKey
     }
 

--- a/sdk-core/src/test/java/care/data4life/sdk/migration/CompatibilityEncoderTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/migration/CompatibilityEncoderTest.kt
@@ -17,7 +17,7 @@
 package care.data4life.sdk.migration
 
 import care.data4life.sdk.tag.TagEncoding
-import care.data4life.sdk.wrapper.URLEncoding
+import care.data4life.sdk.wrapper.UrlEncoding
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
@@ -34,7 +34,7 @@ class CompatibilityEncoderTest {
     @Before
     fun setUp() {
         mockkObject(TagEncoding)
-        mockkObject(URLEncoding)
+        mockkObject(UrlEncoding)
 
         compatibilityEncoder = CompatibilityEncoder
     }
@@ -42,7 +42,7 @@ class CompatibilityEncoderTest {
     @After
     fun tearDown() {
         unmockkObject(TagEncoding)
-        unmockkObject(URLEncoding)
+        unmockkObject(UrlEncoding)
     }
 
     @Test
@@ -60,7 +60,7 @@ class CompatibilityEncoderTest {
 
         every { TagEncoding.encode(tagValue) } returns expected
         every { TagEncoding.normalize(tagValue) } returns "notImportant"
-        every { URLEncoding.encode(tagValue) } returns "notImportant"
+        every { UrlEncoding.encode(tagValue) } returns "notImportant"
 
         // When
         val (encoded, _, _) = compatibilityEncoder.encode(tagValue)
@@ -82,7 +82,7 @@ class CompatibilityEncoderTest {
 
         every { TagEncoding.encode(tagValue) } returns "notImportant"
         every { TagEncoding.normalize(tagValue) } returns expected
-        every { URLEncoding.encode(tagValue) } returns "notImportant"
+        every { UrlEncoding.encode(tagValue) } returns "notImportant"
 
         // When
         val (_, encoded, _) = compatibilityEncoder.encode(tagValue)
@@ -105,7 +105,7 @@ class CompatibilityEncoderTest {
 
         every { TagEncoding.encode(tagValue) } returns "notImportant"
         every { TagEncoding.normalize(tagValue) } returns normalized
-        every { URLEncoding.encode(normalized) } returns expected
+        every { UrlEncoding.encode(normalized) } returns expected
 
         // When
         val (_, _, encoded) = compatibilityEncoder.encode(tagValue)
@@ -117,7 +117,7 @@ class CompatibilityEncoderTest {
         )
 
         verify(exactly = 1) { TagEncoding.normalize(tagValue) }
-        verify(exactly = 1) { URLEncoding.encode(normalized) }
+        verify(exactly = 1) { UrlEncoding.encode(normalized) }
     }
 
     @Test
@@ -128,7 +128,7 @@ class CompatibilityEncoderTest {
 
         every { TagEncoding.encode(tagValue) } returns "notImportant"
         every { TagEncoding.normalize(tagValue) } returns tagValue
-        every { URLEncoding.encode(tagValue) } returns expected.toUpperCase()
+        every { UrlEncoding.encode(tagValue) } returns expected.toUpperCase()
 
         // When
         val (_, _, encoded) = compatibilityEncoder.encode(tagValue)
@@ -140,7 +140,7 @@ class CompatibilityEncoderTest {
         )
 
         verify(exactly = 1) { TagEncoding.normalize(tagValue) }
-        verify(exactly = 1) { URLEncoding.encode(tagValue) }
+        verify(exactly = 1) { UrlEncoding.encode(tagValue) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/migration/CompatibilityEncoderTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/migration/CompatibilityEncoderTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.migration
+
+import care.data4life.sdk.tag.TagEncoding
+import care.data4life.sdk.wrapper.URLEncoding
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CompatibilityEncoderTest {
+    private lateinit var compatibilityEncoder: MigrationContract.CompatibilityEncoder
+
+    @Before
+    fun setUp() {
+        mockkObject(TagEncoding)
+        mockkObject(URLEncoding)
+
+        compatibilityEncoder = CompatibilityEncoder
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(TagEncoding)
+        unmockkObject(URLEncoding)
+    }
+
+    @Test
+    fun `It fulfils CompatibilityEncoder`() {
+        val encoder: Any = CompatibilityEncoder
+
+        assertTrue(encoder is MigrationContract.CompatibilityEncoder)
+    }
+
+    @Test
+    fun `Given encode is called with a String, it delegates the String to encode of the TagEncoder and returns its result as the actual valid encoding`() {
+        // Given
+        val tagValue = "I am a value"
+        val expected = "Well done"
+
+        every { TagEncoding.encode(tagValue) } returns expected
+        every { TagEncoding.normalize(tagValue) } returns "notImportant"
+        every { URLEncoding.encode(tagValue) } returns "notImportant"
+
+        // When
+        val (encoded, _, _) = compatibilityEncoder.encode(tagValue)
+
+        // Then
+        assertEquals(
+            expected = expected,
+            actual = encoded
+        )
+
+        verify(exactly = 1) { TagEncoding.encode(tagValue) }
+    }
+
+    @Test
+    fun `Given encode is called with a String, it delegates the String to normalize of the TagEncoder and returns its result as Android legacy encoding`() {
+        // Given
+        val tagValue = "I am a value"
+        val expected = "Well done"
+
+        every { TagEncoding.encode(tagValue) } returns "notImportant"
+        every { TagEncoding.normalize(tagValue) } returns expected
+        every { URLEncoding.encode(tagValue) } returns "notImportant"
+
+        // When
+        val (_, encoded, _) = compatibilityEncoder.encode(tagValue)
+
+        // Then
+        assertEquals(
+            expected = expected,
+            actual = encoded
+        )
+
+        verify(exactly = 1) { TagEncoding.normalize(tagValue) }
+    }
+
+    @Test
+    fun `Given encode is called with a String, it delegates the String to encode of the URLEncoder and returns its result as JS legacy encoding`() {
+        // Given
+        val tagValue = "I am a value"
+        val expected = "Well done"
+        val normalized = "Soon"
+
+        every { TagEncoding.encode(tagValue) } returns "notImportant"
+        every { TagEncoding.normalize(tagValue) } returns normalized
+        every { URLEncoding.encode(normalized) } returns expected
+
+        // When
+        val (_, _, encoded) = compatibilityEncoder.encode(tagValue)
+
+        // Then
+        assertEquals(
+            expected = expected,
+            actual = encoded
+        )
+
+        verify(exactly = 1) { TagEncoding.normalize(tagValue) }
+        verify(exactly = 1) { URLEncoding.encode(normalized) }
+    }
+
+    @Test
+    fun `Given encode is called with a String, it maps JS legacy encoding lowercases`() {
+        // Given
+        val tagValue = "!'()*-_.~"
+        val expected = "%21%27%28%29%2a%2d%5f%2e%7e"
+
+        every { TagEncoding.encode(tagValue) } returns "notImportant"
+        every { TagEncoding.normalize(tagValue) } returns tagValue
+        every { URLEncoding.encode(tagValue) } returns expected.toUpperCase()
+
+        // When
+        val (_, _, encoded) = compatibilityEncoder.encode(tagValue)
+
+        // Then
+        assertEquals(
+            expected = expected,
+            actual = encoded
+        )
+
+        verify(exactly = 1) { TagEncoding.normalize(tagValue) }
+        verify(exactly = 1) { URLEncoding.encode(tagValue) }
+    }
+
+    @Test
+    fun `Given normalize is called with a String, it passes it through to the TagEncoder and returns its result`() {
+        // Given
+        val tagValue = "AAA"
+        val expected = "BBB"
+
+        every { TagEncoding.normalize(tagValue) } returns expected
+
+        // When
+        val normalized = compatibilityEncoder.normalize(tagValue)
+
+        // Then
+        assertEquals(
+            expected = expected,
+            actual = normalized
+        )
+
+        verify(exactly = 1) { TagEncoding.normalize(tagValue) }
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/migration/RecordCompatibilityServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/migration/RecordCompatibilityServiceTest.kt
@@ -19,29 +19,22 @@ package care.data4life.sdk.migration
 import care.data4life.crypto.GCKey
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.network.NetworkingContract
-import care.data4life.sdk.network.model.EncryptedRecord
-import care.data4life.sdk.tag.Annotations
 import care.data4life.sdk.tag.TaggingContract
-import care.data4life.sdk.tag.TaggingContract.Companion.ANNOTATION_KEY
-import care.data4life.sdk.tag.TaggingContract.Companion.DELIMITER
-import care.data4life.sdk.tag.Tags
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
-import io.reactivex.Observable
-import io.reactivex.Single
 import org.junit.Before
 import org.junit.Test
-import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class RecordCompatibilityServiceTest {
-    private var apiService: NetworkingContract.Service = mockk()
-    private var tagCryptoService: TaggingContract.CryptoService = mockk()
-    private var cryptoService: CryptoContract.Service = mockk()
-    private var tagEncryptionEncoding: TaggingContract.Encoding = mockk()
+    private val cryptoService: CryptoContract.Service = mockk()
+    private val tagCryptoService: TaggingContract.CryptoService = mockk()
+    private val compatibilityEncoder: MigrationContract.CompatibilityEncoder = mockk()
+    private val searchTagsBuilderFactory: NetworkingContract.SearchTagsBuilderFactory = mockk()
+    private val searchTagsPipe: NetworkingContract.SearchTagsBuilder = mockk()
     private lateinit var service: MigrationContract.CompatibilityService
 
     @Before
@@ -49,319 +42,373 @@ class RecordCompatibilityServiceTest {
         clearAllMocks()
 
         service = RecordCompatibilityService(
-            apiService,
-            tagCryptoService,
             cryptoService,
-            tagEncryptionEncoding
+            tagCryptoService,
+            compatibilityEncoder,
+            searchTagsBuilderFactory
         )
     }
 
     @Test
-    fun `it fulfills the CompatibilityService`() {
-        val service: Any = RecordCompatibilityService(mockk(), mockk(), mockk(), mockk())
+    fun `It fulfills the CompatibilityService`() {
+        val service: Any = RecordCompatibilityService(cryptoService, tagCryptoService)
         assertTrue(service is MigrationContract.CompatibilityService)
     }
 
-    private fun encryptTagsAndAnnotationsFlow(
-        tags: Tags,
-        annotations: Annotations,
-        encodedAndEncryptedTagsAndAnnotations: MutableList<String>,
-        encryptedTags: MutableList<String>,
-        encryptedAnnotations: MutableList<String>,
-        encryptionKey: GCKey
-    ) {
-        every { cryptoService.fetchTagEncryptionKey() } returns encryptionKey
-        every {
-            tagCryptoService.encryptTagsAndAnnotations(tags, annotations, encryptionKey)
-        } returns encodedAndEncryptedTagsAndAnnotations
+    @Test
+    fun `Given, resolveSearchTags is called with proper Arguments, setsUp a new SearchTagsPipeIn`() {
+        // Given
+        val tagEncryptionKey: GCKey = mockk()
 
-        every {
-            tagCryptoService.encryptList(
-                annotations,
-                encryptionKey,
-                ANNOTATION_KEY + DELIMITER
-            )
-        } returns encryptedAnnotations
+        every { cryptoService.fetchTagEncryptionKey() } returns tagEncryptionKey
+        every { searchTagsBuilderFactory.newBuilder() } returns mockk(relaxed = true)
 
-        every { tagEncryptionEncoding.normalize(tags["key"]!!) } returns tags["key"]!!
-        every {
-            tagCryptoService.encryptList(
-                eq(listOf("key=value")),
-                encryptionKey
-            )
-        } returns encryptedTags
-    }
+        // When
+        service.resolveSearchTags(emptyMap(), emptyList())
 
-    private fun verifyEncryptTagsAndAnnotationsFlow(
-        tags: Tags,
-        annotations: Annotations,
-        encryptionKey: GCKey
-    ) {
+        // Then
         verify(exactly = 1) { cryptoService.fetchTagEncryptionKey() }
-        verify(exactly = 1) {
-            tagCryptoService.encryptTagsAndAnnotations(tags, annotations, encryptionKey)
-        }
-        verify(exactly = 1) { tagEncryptionEncoding.normalize(tags["key"]!!) }
-        verify(exactly = 2) {
+        verify(exactly = 1) { searchTagsBuilderFactory.newBuilder() }
+    }
+
+    @Test
+    fun `Given, resolveSearchTags is called with proper Arguments, it seals the SearchTags and returns them`() {
+        // Given
+        val sealedSearchTags: NetworkingContract.SearchTags = mockk()
+
+        every { cryptoService.fetchTagEncryptionKey() } returns mockk()
+
+        every { searchTagsBuilderFactory.newBuilder() } returns searchTagsPipe
+        every { searchTagsPipe.seal() } returns sealedSearchTags
+
+        // When
+        val tags = service.resolveSearchTags(emptyMap(), emptyList())
+
+        // Then
+        assertSame(
+            expected = sealedSearchTags,
+            actual = tags
+        )
+        verify(exactly = 1) { searchTagsPipe.seal() }
+    }
+
+    // Tags
+    @Test
+    fun `Given, resolveSearchTags is called with Tags, delegates the plain Tags to the CompatibilityEncoder`() {
+        // Given
+        val tags = mapOf(
+            "tag1" to "tag1Value",
+            "tag2" to "tag2Value",
+            "tag3" to "tag3Value"
+        )
+
+        every { compatibilityEncoder.encode(tags["tag1"]!!) } returns mockk(relaxed = true)
+        every { compatibilityEncoder.encode(tags["tag2"]!!) } returns mockk(relaxed = true)
+        every { compatibilityEncoder.encode(tags["tag3"]!!) } returns mockk(relaxed = true)
+
+        every { cryptoService.fetchTagEncryptionKey() } returns mockk()
+        every { tagCryptoService.encryptList(any(), any(), any()) } returns mockk()
+
+        every { searchTagsBuilderFactory.newBuilder() } returns mockk(relaxed = true)
+
+        // When
+        service.resolveSearchTags(tags, emptyList())
+
+        // Then
+        verify(atMost = 1) { compatibilityEncoder.encode(tags["tag1"]!!) }
+        verify(atMost = 1) { compatibilityEncoder.encode(tags["tag2"]!!) }
+        verify(atMost = 1) { compatibilityEncoder.encode(tags["tag3"]!!) }
+    }
+
+    @Test
+    fun `Given, resolveSearchTags is called with Tags, delegates the TagGroupKey and the TagGroupValue to the TagCryptoService`() {
+        // Given
+        val tagEncryptionKey: GCKey = mockk()
+        val tags = mapOf(
+            "tag1" to "tag1Value",
+            "tag2" to "tag2Value",
+            "tag3" to "tag3Value"
+        )
+        val encodedTags = listOf(
+            Triple("encodedTag1Value", "encodedAndroidLegacyTag1Value", "encodedJSLegacyTag1Value"),
+            Triple("encodedTag2Value", "encodedAndroidLegacyTag2Value", "encodedJSLegacyTag2Value"),
+            Triple("encodedTag3Value", "encodedAndroidLegacyTag3Value", "encodedJSLegacyTag3Value")
+        )
+
+        every { compatibilityEncoder.encode(tags["tag1"]!!) } returns encodedTags[0]
+        every { compatibilityEncoder.encode(tags["tag2"]!!) } returns encodedTags[1]
+        every { compatibilityEncoder.encode(tags["tag3"]!!) } returns encodedTags[2]
+
+        every { cryptoService.fetchTagEncryptionKey() } returns tagEncryptionKey
+
+        every { searchTagsBuilderFactory.newBuilder() } returns mockk(relaxed = true)
+
+        every {
             tagCryptoService.encryptList(
-                or(eq(listOf("key=value")), annotations),
-                or(encryptionKey, encryptionKey),
-                or("", ANNOTATION_KEY + DELIMITER)
+                encodedTags[0].toList(),
+                tagEncryptionKey,
+                "${tags.keys.toList()[0]}${TaggingContract.DELIMITER}"
+            )
+        } returns mockk()
+
+        every {
+            tagCryptoService.encryptList(
+                encodedTags[1].toList(),
+                tagEncryptionKey,
+                "${tags.keys.toList()[1]}${TaggingContract.DELIMITER}"
+            )
+        } returns mockk()
+
+        every {
+            tagCryptoService.encryptList(
+                encodedTags[2].toList(),
+                tagEncryptionKey,
+                "${tags.keys.toList()[2]}${TaggingContract.DELIMITER}"
+            )
+        } returns mockk()
+
+        // When
+        service.resolveSearchTags(tags, emptyList())
+
+        // Then
+        verify(atMost = 1) {
+            tagCryptoService.encryptList(
+                encodedTags[0].toList(),
+                tagEncryptionKey,
+                "${tags.keys.toList()[0]}${TaggingContract.DELIMITER}"
+            )
+        }
+
+        verify(atMost = 1) {
+            tagCryptoService.encryptList(
+                encodedTags[1].toList(),
+                tagEncryptionKey,
+                "${tags.keys.toList()[1]}${TaggingContract.DELIMITER}"
+            )
+        }
+
+        verify(atMost = 1) {
+            tagCryptoService.encryptList(
+                encodedTags[2].toList(),
+                tagEncryptionKey,
+                "${tags.keys.toList()[2]}${TaggingContract.DELIMITER}"
             )
         }
     }
 
     @Test
-    fun `Given countRecords is called, with a Alias, UserId and Tags, it calls the ApiService twice with the encodedAndEncrypted and the encrypted Tags`() {
+    fun `Given, resolveSearchTags is called with Tags, it adds the encrypted OrGroup to the SearchTagsPipe`() {
         // Given
-        val alias = "alias"
-        val userId = "id"
-        val tags = hashMapOf("key" to "value")
-        val annotations: Annotations = mockk()
-        val encryptedTags = mutableListOf("a", "k")
-        val encryptedAnnotations = mutableListOf("d")
-        val expected = 42
-        val encryptionKey: GCKey = mockk()
-        val encodedAndEncryptedTagsAndAnnotations = mutableListOf("a", "v")
-            .also {
-                it.addAll(listOf("d"))
-            }
-        val indicator = slot<String>()
-
-        encryptTagsAndAnnotationsFlow(
-            tags,
-            annotations,
-            encodedAndEncryptedTagsAndAnnotations,
-            encryptedTags,
-            encryptedAnnotations,
-            encryptionKey
+        val tags = mapOf(
+            "tag1" to "tag1Value",
+            "tag2" to "tag2Value",
+            "tag3" to "tag3Value"
         )
+        val encodedTags = listOf(
+            Triple("encodedTag1Value", "encodedAndroidLegacyTag1Value", "encodedJSLegacyTag1Value"),
+            Triple("encodedTag2Value", "encodedAndroidLegacyTag2Value", "encodedJSLegacyTag2Value"),
+            Triple("encodedTag3Value", "encodedAndroidLegacyTag3Value", "encodedJSLegacyTag3Value")
+        )
+        val encryptedGroups = listOf<MutableList<String>>(mockk(), mockk(), mockk())
+
+        every { cryptoService.fetchTagEncryptionKey() } returns mockk()
+
+        every { compatibilityEncoder.encode(tags["tag1"]!!) } returns encodedTags[0]
+        every { compatibilityEncoder.encode(tags["tag2"]!!) } returns encodedTags[1]
+        every { compatibilityEncoder.encode(tags["tag3"]!!) } returns encodedTags[2]
 
         every {
-            apiService.getCount(
-                alias,
-                userId,
-                capture(indicator)
-            )
-        } answers {
-            when (indicator.captured) {
-                encodedAndEncryptedTagsAndAnnotations.joinToString(",") -> Single.just(21)
-                encryptedTags.joinToString(",") -> Single.just(21)
-                else -> throw RuntimeException("Unknown tags ${indicator.captured}")
-            }
-        }
+            tagCryptoService.encryptList(encodedTags[0].toList(), any(), any())
+        } returns encryptedGroups[0]
+
+        every {
+            tagCryptoService.encryptList(encodedTags[1].toList(), any(), any())
+        } returns encryptedGroups[1]
+
+        every {
+            tagCryptoService.encryptList(encodedTags[2].toList(), any(), any())
+        } returns encryptedGroups[2]
+
+        every { searchTagsBuilderFactory.newBuilder() } returns searchTagsPipe
+        every { searchTagsPipe.addOrTuple(encryptedGroups[0]) } returns searchTagsPipe
+        every { searchTagsPipe.addOrTuple(encryptedGroups[1]) } returns searchTagsPipe
+        every { searchTagsPipe.addOrTuple(encryptedGroups[2]) } returns searchTagsPipe
+        every { searchTagsPipe.seal() } returns mockk()
 
         // When
-        val observer = service.countRecords(alias, userId, tags, annotations).test().await()
+        service.resolveSearchTags(tags, emptyList())
 
         // Then
-        val result = observer
-            .assertComplete()
-            .assertValueCount(1)
-            .values()[0]
+        verify(atLeast = 1) { searchTagsPipe.addOrTuple(encryptedGroups[0]) }
+        verify(atLeast = 1) { searchTagsPipe.addOrTuple(encryptedGroups[1]) }
+        verify(atLeast = 1) { searchTagsPipe.addOrTuple(encryptedGroups[2]) }
+    }
 
-        assertEquals(
-            expected = expected,
-            actual = result
+    // Annotations
+    @Test
+    fun `Given, resolveSearchTags is called with Annotations, delegates the plain Tags to the CompatibilityEncoder`() {
+        // Given
+        val annotations = listOf(
+            "annotation1Value",
+            "annotation2Value",
+            "annotation3Value"
         )
 
-        verifyEncryptTagsAndAnnotationsFlow(
-            tags,
-            annotations,
-            encryptionKey
+        every { compatibilityEncoder.encode(annotations[0]) } returns mockk(relaxed = true)
+        every { compatibilityEncoder.encode(annotations[1]) } returns mockk(relaxed = true)
+        every { compatibilityEncoder.encode(annotations[2]) } returns mockk(relaxed = true)
+
+        every { compatibilityEncoder.normalize(annotations[0]) } returns "a"
+        every { compatibilityEncoder.normalize(annotations[1]) } returns "b"
+        every { compatibilityEncoder.normalize(annotations[2]) } returns "c"
+
+        every { cryptoService.fetchTagEncryptionKey() } returns mockk()
+        every { tagCryptoService.encryptList(any(), any(), any()) } returns mockk()
+
+        every { searchTagsBuilderFactory.newBuilder() } returns mockk(relaxed = true)
+
+        // When
+        service.resolveSearchTags(emptyMap(), annotations)
+
+        // Then
+        verify(atMost = 1) { compatibilityEncoder.encode(annotations[0]) }
+        verify(atMost = 1) { compatibilityEncoder.encode(annotations[1]) }
+        verify(atMost = 1) { compatibilityEncoder.encode(annotations[2]) }
+    }
+
+    @Test
+    fun `Given, resolveSearchTags is called with Annotations, delegates the TagGroupKey and the TagGroupValue to the TagCryptoService`() {
+        // Given
+        val tagEncryptionKey: GCKey = mockk()
+        val annotations = listOf(
+            "annotation1Value",
+            "annotation2Value",
+            "annotation3Value"
         )
-        verify(exactly = 2) {
-            apiService.getCount(
-                alias,
-                userId,
-                or(
-                    encodedAndEncryptedTagsAndAnnotations.joinToString(","),
-                    encryptedTags.joinToString(",")
-                )
+        val encodedTags = listOf(
+            Triple("encodedTag1Value", "encodedAndroidLegacyTag1Value", "encodedJSLegacyTag1Value"),
+            Triple("encodedTag2Value", "encodedAndroidLegacyTag2Value", "encodedJSLegacyTag2Value"),
+            Triple("encodedTag3Value", "encodedAndroidLegacyTag3Value", "encodedJSLegacyTag3Value")
+        )
+
+        every { compatibilityEncoder.encode(annotations[0]) } returns encodedTags[0]
+        every { compatibilityEncoder.encode(annotations[1]) } returns encodedTags[1]
+        every { compatibilityEncoder.encode(annotations[2]) } returns encodedTags[2]
+
+        every { cryptoService.fetchTagEncryptionKey() } returns tagEncryptionKey
+
+        every { searchTagsBuilderFactory.newBuilder() } returns mockk(relaxed = true)
+
+        every {
+            tagCryptoService.encryptList(
+                encodedTags[0].copy(second = annotations[0]).toList(),
+                tagEncryptionKey,
+                "${TaggingContract.ANNOTATION_KEY}${TaggingContract.DELIMITER}"
+            )
+        } returns mockk()
+
+        every {
+            tagCryptoService.encryptList(
+                encodedTags[1].copy(second = annotations[1]).toList(),
+                tagEncryptionKey,
+                "${TaggingContract.ANNOTATION_KEY}${TaggingContract.DELIMITER}"
+            )
+        } returns mockk()
+
+        every {
+            tagCryptoService.encryptList(
+                encodedTags[2].copy(second = annotations[2]).toList(),
+                tagEncryptionKey,
+                "${TaggingContract.ANNOTATION_KEY}${TaggingContract.DELIMITER}"
+            )
+        } returns mockk()
+
+        // When
+        service.resolveSearchTags(emptyMap(), annotations)
+
+        // Then
+        verify(atMost = 1) {
+            tagCryptoService.encryptList(
+                encodedTags[0].copy(second = annotations[0]).toList(),
+                tagEncryptionKey,
+                "${TaggingContract.ANNOTATION_KEY}${TaggingContract.DELIMITER}"
+            )
+        }
+
+        verify(atMost = 1) {
+            tagCryptoService.encryptList(
+                encodedTags[1].copy(second = annotations[1]).toList(),
+                tagEncryptionKey,
+                "${TaggingContract.ANNOTATION_KEY}${TaggingContract.DELIMITER}"
+            )
+        }
+
+        verify(atMost = 1) {
+            tagCryptoService.encryptList(
+                encodedTags[2].copy(second = annotations[2]).toList(),
+                tagEncryptionKey,
+                "${TaggingContract.ANNOTATION_KEY}${TaggingContract.DELIMITER}"
             )
         }
     }
 
     @Test
-    fun `Given searchRecords is called with a UserId, a ResourceType, a StartDate, a EndDate, the PageSize, Offset, Tags and Annotations, it calls the ApiService twice with the encodedAndEncrypted and the encrypted Tags`() {
+    fun `Given, resolveSearchTags is called with Annotations, it adds the encrypted OrGroup to the SearchTagsPipe`() {
         // Given
-        val alias = "alias"
-        val userId = "id"
-        val startTime = "start"
-        val endTime = "end"
-        val pageSize = 23
-        val offset = 42
-        val tags = hashMapOf("key" to "value")
-        val annotations: Annotations = mockk()
-        val encodedAndEncryptedTagsAndAnnotations: MutableList<String> = mutableListOf("a", "v")
-            .also {
-                it.addAll(listOf("d"))
-            }
-        val encryptedTags: MutableList<String> = mutableListOf("a", "k")
-        val encryptedAnnotations: MutableList<String> = mutableListOf("d")
-        val encryptionKey: GCKey = mockk()
-        val encryptedRecord1: EncryptedRecord = mockk()
-        val encryptedRecord2: EncryptedRecord = mockk()
-        val indicator = slot<String>()
-
-        encryptTagsAndAnnotationsFlow(
-            tags,
-            annotations,
-            encodedAndEncryptedTagsAndAnnotations,
-            encryptedTags,
-            encryptedAnnotations,
-            encryptionKey
+        val annotations = listOf(
+            "annotation1Value",
+            "annotation2Value",
+            "annotation3Value"
         )
+        val encodedTags = listOf(
+            Triple("encodedTag1Value", "encodedAndroidLegacyTag1Value", "encodedJSLegacyTag1Value"),
+            Triple("encodedTag2Value", "encodedAndroidLegacyTag2Value", "encodedJSLegacyTag2Value"),
+            Triple("encodedTag3Value", "encodedAndroidLegacyTag3Value", "encodedJSLegacyTag3Value")
+        )
+        val encryptedGroups = listOf<MutableList<String>>(mockk(), mockk(), mockk())
+
+        every { cryptoService.fetchTagEncryptionKey() } returns mockk()
+
+        every { compatibilityEncoder.encode(annotations[0]) } returns encodedTags[0]
+        every { compatibilityEncoder.encode(annotations[1]) } returns encodedTags[1]
+        every { compatibilityEncoder.encode(annotations[2]) } returns encodedTags[2]
+
         every {
-            apiService.searchRecords(
-                alias,
-                userId,
-                startTime,
-                endTime,
-                pageSize,
-                offset,
-                capture(indicator)
+            tagCryptoService.encryptList(
+                encodedTags[0].copy(second = annotations[0]).toList(),
+                any(),
+                any()
             )
-        } answers {
-            when (indicator.captured) {
-                encodedAndEncryptedTagsAndAnnotations.joinToString(",") -> Observable.fromArray(
-                    listOf(encryptedRecord1)
-                )
-                encryptedTags.joinToString(",") -> Observable.fromArray(listOf(encryptedRecord2))
-                else -> throw RuntimeException("Unknown tags ${indicator.captured}")
-            }
-        }
+        } returns encryptedGroups[0]
+
+        every {
+            tagCryptoService.encryptList(
+                encodedTags[1].copy(second = annotations[1]).toList(),
+                any(),
+                any()
+            )
+        } returns encryptedGroups[1]
+
+        every {
+            tagCryptoService.encryptList(
+                encodedTags[2].copy(second = annotations[2]).toList(),
+                any(),
+                any()
+            )
+        } returns encryptedGroups[2]
+
+        every { searchTagsBuilderFactory.newBuilder() } returns searchTagsPipe
+        every { searchTagsPipe.addOrTuple(encryptedGroups[0]) } returns searchTagsPipe
+        every { searchTagsPipe.addOrTuple(encryptedGroups[1]) } returns searchTagsPipe
+        every { searchTagsPipe.addOrTuple(encryptedGroups[2]) } returns searchTagsPipe
+        every { searchTagsPipe.seal() } returns mockk()
 
         // When
-        val observer = service.searchRecords(
-            alias,
-            userId,
-            startTime,
-            endTime,
-            pageSize,
-            offset,
-            tags,
-            annotations
-        ).test().await()
+        service.resolveSearchTags(emptyMap(), annotations)
 
         // Then
-        val result = observer
-            .assertComplete()
-            .assertValueCount(1)
-            .values()[0]
-
-        assertEquals(
-            expected = listOf(encryptedRecord1, encryptedRecord2),
-            actual = result
-        )
-
-        verifyEncryptTagsAndAnnotationsFlow(
-            tags,
-            annotations,
-            encryptionKey
-        )
-        verify(exactly = 2) {
-            apiService.searchRecords(
-                alias,
-                userId,
-                startTime,
-                endTime,
-                pageSize,
-                offset,
-                or(
-                    encodedAndEncryptedTagsAndAnnotations.joinToString(","),
-                    encryptedTags.joinToString(",")
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `Given searchRecords is called with its appropriate parameter, it calls the ApiService only if the legacy encrypted tags equal the current version of encrypted tags`() {
-        // Given
-        val alias = "alias"
-        val userId = "id"
-        val startTime = "start"
-        val endTime = "end"
-        val pageSize = 23
-        val offset = 42
-        val tags = hashMapOf("key" to "value")
-        val annotations: Annotations = mockk()
-        val encodedAndEncryptedTagsAndAnnotations: MutableList<String> =
-            mutableListOf("a", "b", "c")
-        val encryptedTags: MutableList<String> = mutableListOf("c", "b", "a")
-        val encryptionKey: GCKey = mockk()
-        val encryptedAnnotations: MutableList<String> = mutableListOf()
-        val encryptedRecord1: EncryptedRecord = mockk()
-        val encryptedRecord2: EncryptedRecord = mockk()
-        val indicator = slot<String>()
-
-        encryptTagsAndAnnotationsFlow(
-            tags,
-            annotations,
-            encodedAndEncryptedTagsAndAnnotations,
-            encryptedTags,
-            encryptedAnnotations,
-            encryptionKey
-        )
-        every {
-            apiService.searchRecords(
-                alias,
-                userId,
-                startTime,
-                endTime,
-                pageSize,
-                offset,
-                capture(indicator)
-            )
-        } answers {
-            when (indicator.captured) {
-                encodedAndEncryptedTagsAndAnnotations.joinToString(",") -> Observable.fromArray(
-                    listOf(encryptedRecord1)
-                )
-                encryptedTags.joinToString(",") -> Observable.fromArray(listOf(encryptedRecord2))
-                else -> throw RuntimeException("Unknown tags ${indicator.captured}")
-            }
-        }
-
-        // When
-        val observer = service.searchRecords(
-            alias,
-            userId,
-            startTime,
-            endTime,
-            pageSize,
-            offset,
-            tags,
-            annotations
-        ).test().await()
-
-        // Then
-        val result = observer
-            .assertComplete()
-            .assertValueCount(1)
-            .values()[0]
-
-        assertEquals(
-            expected = listOf(encryptedRecord1),
-            actual = result
-        )
-
-        verifyEncryptTagsAndAnnotationsFlow(
-            tags,
-            annotations,
-            encryptionKey
-        )
-        verify(exactly = 1) {
-            apiService.searchRecords(
-                alias,
-                userId,
-                startTime,
-                endTime,
-                pageSize,
-                offset,
-                encodedAndEncryptedTagsAndAnnotations.joinToString(",")
-            )
-        }
+        verify(atLeast = 1) { searchTagsPipe.addOrTuple(encryptedGroups[0]) }
+        verify(atLeast = 1) { searchTagsPipe.addOrTuple(encryptedGroups[1]) }
+        verify(atLeast = 1) { searchTagsPipe.addOrTuple(encryptedGroups[2]) }
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceModuleTest.kt
@@ -30,6 +30,7 @@ import care.data4life.sdk.network.model.UserInfo
 import care.data4life.sdk.network.model.Version
 import care.data4life.sdk.network.model.VersionList
 import care.data4life.sdk.network.typeadapter.EncryptedKeyTypeAdapter
+import care.data4life.sdk.network.util.SearchTagsBuilder
 import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
 import care.data4life.sdk.test.util.GenericTestDataProvider.AUTH_TOKEN
 import care.data4life.sdk.test.util.GenericTestDataProvider.CLIENT_ID
@@ -339,7 +340,12 @@ class ApiServiceModuleTest {
         val endDate = "somewhen else"
         val pageSize = 23
         val offset = 42
-        val tags = "tag1,tag2,tag"
+        val formattedTags = "tag1,tag2,tag3"
+        val tags = SearchTagsBuilder.newBuilder()
+            .addOrTuple(listOf("tag1"))
+            .addOrTuple(listOf("tag2"))
+            .addOrTuple(listOf("tag3"))
+            .seal()
 
         val recordResponse = EncryptedRecord(
             _commonKeyId = null,
@@ -410,7 +416,7 @@ class ApiServiceModuleTest {
         )
         assertEquals(
             actual = request.requestUrl!!.queryParameter("tags"),
-            expected = tags
+            expected = formattedTags
         )
         assertEquals(
             actual = request.method,
@@ -423,7 +429,12 @@ class ApiServiceModuleTest {
         // Given
         val alias = ALIAS
         val userId = USER_ID
-        val tags = "tag1,tag2,tag"
+        val formattedTags = "tag1,tag2,tag3"
+        val tags = SearchTagsBuilder.newBuilder()
+            .addOrTuple(listOf("tag1"))
+            .addOrTuple(listOf("tag2"))
+            .addOrTuple(listOf("tag3"))
+            .seal()
         val amount = 23
         val authToken = AUTH_TOKEN
 
@@ -433,7 +444,7 @@ class ApiServiceModuleTest {
         simulateAuthService(alias, authToken)
 
         // When
-        val actual = service.getCount(alias, userId, tags).blockingGet()
+        val actual = service.countRecord(alias, userId, tags).blockingGet()
 
         // Then
         assertEquals(
@@ -445,7 +456,7 @@ class ApiServiceModuleTest {
 
         assertEquals(
             actual = request.path,
-            expected = "/users/$userId/records?tags=${tags.replace(",", "%2C")}"
+            expected = "/users/$userId/records?tags=${formattedTags.replace(",", "%2C")}"
         )
         assertNull(request.headers[HEADER_ALIAS])
         assertEquals(

--- a/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceModuleTest.kt
@@ -444,7 +444,7 @@ class ApiServiceModuleTest {
         simulateAuthService(alias, authToken)
 
         // When
-        val actual = service.countRecord(alias, userId, tags).blockingGet()
+        val actual = service.countRecords(alias, userId, tags).blockingGet()
 
         // Then
         assertEquals(

--- a/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceTest.kt
@@ -312,7 +312,7 @@ class ApiServiceTest {
         every { headers[NetworkingContract.HEADER_TOTAL_COUNT] } returns amount
 
         // When
-        val actual = service.countRecord(alias, userId, tags).blockingGet()
+        val actual = service.countRecords(alias, userId, tags).blockingGet()
 
         // Then
         assertSame(

--- a/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/network/ApiServiceTest.kt
@@ -261,12 +261,15 @@ class ApiServiceTest {
         val endDate = "somewhen else"
         val pageSize = 23
         val offset = 42
-        val tags = "tags"
+        val formattedTags = "tags"
+        val tags: NetworkingContract.SearchTags = mockk()
         val result: Observable<List<EncryptedRecord>> = mockk()
 
         every {
-            service.searchRecords(alias, userId, startDate, endDate, pageSize, offset, tags)
+            ihcService.searchRecords(alias, userId, startDate, endDate, pageSize, offset, formattedTags)
         } returns result
+
+        every { tags.tags } returns formattedTags
 
         // When
         val actual = service.searchRecords(
@@ -286,26 +289,30 @@ class ApiServiceTest {
         )
 
         verify(exactly = 1) {
-            ihcService.searchRecords(alias, userId, startDate, endDate, pageSize, offset, tags)
+            ihcService.searchRecords(alias, userId, startDate, endDate, pageSize, offset, formattedTags)
         }
+
+        verify(exactly = 1) { tags.tags }
     }
 
     @Test
-    fun `Given, getCount is called with an Alias, UserId and Tags, it delegates it to the IHCService, parses the result and returns it`() {
+    fun `Given, countRecords is called with an Alias, UserId and Tags, it delegates it to the IHCService, parses the result and returns it`() {
         // Given
         val alias = ALIAS
         val userId = USER_ID
-        val tags = RECORD_ID
+        val formattedTags = "tags"
+        val tags: NetworkingContract.SearchTags = mockk()
         val amount = "23"
         val response: Response<Void> = mockk()
         val headers: Headers = mockk()
 
-        every { ihcService.getRecordsHeader(alias, userId, tags) } returns Single.just(response)
+        every { tags.tags } returns formattedTags
+        every { ihcService.getRecordsHeader(alias, userId, formattedTags) } returns Single.just(response)
         every { response.headers() } returns headers
         every { headers[NetworkingContract.HEADER_TOTAL_COUNT] } returns amount
 
         // When
-        val actual = service.getCount(alias, userId, tags).blockingGet()
+        val actual = service.countRecord(alias, userId, tags).blockingGet()
 
         // Then
         assertSame(
@@ -314,8 +321,9 @@ class ApiServiceTest {
         )
 
         verify(exactly = 1) {
-            ihcService.getRecordsHeader(alias, userId, tags)
+            ihcService.getRecordsHeader(alias, userId, formattedTags)
         }
+        verify(exactly = 1) { tags.tags }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/network/util/SearchTagsBuilderTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/network/util/SearchTagsBuilderTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.network.util
+
+import care.data4life.sdk.network.NetworkingContract
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class SearchTagsBuilderTest {
+    private lateinit var builder: NetworkingContract.SearchTagsBuilder
+
+    @Before
+    fun setUp() {
+        builder = SearchTagsBuilder.newBuilder()
+    }
+
+    @Test
+    fun `It fulfils SearchTagsBuilderFactory`() {
+        val factory: Any = SearchTagsBuilder
+
+        assertTrue(factory is NetworkingContract.SearchTagsBuilderFactory)
+    }
+
+    @Test
+    fun `Given newBuilder is called, it returns a SearchTagsBuilder`() {
+        val builder: Any = SearchTagsBuilder.newBuilder()
+
+        assertTrue(builder is NetworkingContract.SearchTagsBuilder)
+    }
+
+    @Test
+    fun `Given seal is called on existing builder, it returns a SearchTags`() {
+        val builder: Any = SearchTagsBuilder.newBuilder().seal()
+
+        assertTrue(builder is NetworkingContract.SearchTags)
+    }
+
+    @Test
+    fun `Given addOrTuple on existing builder is called, it returns the SearchTagsBuilder`() {
+        val builder: Any = this.builder.addOrTuple(mockk())
+
+        assertSame(
+            actual = builder,
+            expected = builder
+        )
+    }
+
+    @Test
+    fun `Given before seal is called on existing builder, addOrTuple with an arbitrary number of singles it returns a comma separated list`() {
+        // Given
+        val singles = listOf(
+            listOf("a"),
+            listOf("b"),
+            listOf("c"),
+            listOf("d"),
+            listOf("e"),
+        )
+
+        // When
+        var builder = this.builder
+        singles.forEach { single -> builder = builder.addOrTuple(single) }
+
+        val searchTags = builder.seal().tags
+
+        // Then
+        assertEquals(
+            actual = searchTags,
+            expected = "a,b,c,d,e"
+        )
+    }
+
+    @Test
+    fun `Given before seal is called on existing builder, addOrTuple with an arbitrary number of singles, which contain duplicates, it removes them and it returns a comma separated list`() {
+        // Given
+        val singles = listOf(
+            listOf("a"),
+            listOf("b"),
+            listOf("a"),
+            listOf("d"),
+            listOf("a"),
+        )
+
+        // When
+        var builder = this.builder
+        singles.forEach { single -> builder = builder.addOrTuple(single) }
+
+        val searchTags = builder.seal().tags
+
+        // Then
+        assertEquals(
+            actual = searchTags,
+            expected = "a,b,d"
+        )
+    }
+
+    @Test
+    fun `Given before seal is called on existing builder, addOrTuple with an arbitrary number of arbitrary tuples it removes duplicates in the tuples, while bracing them`() {
+        // Given
+        val singles = listOf(
+            listOf("a", "a", "b"),
+            listOf("c", "d", "c"),
+            listOf("e", "f")
+        )
+
+        // When
+        var builder = this.builder
+        singles.forEach { single -> builder = builder.addOrTuple(single) }
+
+        val searchTags = builder.seal().tags
+
+        // Then
+        assertEquals(
+            actual = searchTags,
+            expected = "(a,b),(c,d),(e,f)"
+        )
+    }
+
+    @Test
+    fun `Given before seal is called on existing builder, addOrTuple with an arbitrary number of arbitrary tuples it returns a comma separated list, while bracing tuples`() {
+        // Given
+        val singles = listOf(
+            listOf("a", "b", "c"),
+            listOf("d", "e", "f"),
+            listOf("g", "h")
+        )
+
+        // When
+        var builder = this.builder
+        singles.forEach { single -> builder = builder.addOrTuple(single) }
+
+        val searchTags = builder.seal().tags
+
+        // Then
+        assertEquals(
+            actual = searchTags,
+            expected = "(a,b,c),(d,e,f),(g,h)"
+        )
+    }
+
+    @Test
+    fun `Given before seal is called on existing builder, addOrTuple with an arbitrary number of arbitrary tuples it returns a comma separated list, it determines braces correctly`() {
+        // Given
+        val singles = listOf(
+            listOf("a", "a"),
+            listOf("b", "c"),
+            listOf("d", "d", "d"),
+            listOf("e", "f")
+        )
+
+        // When
+        var builder = this.builder
+        singles.forEach { single -> builder = builder.addOrTuple(single) }
+
+        val searchTags = builder.seal().tags
+
+        // Then
+        assertEquals(
+            actual = searchTags,
+            expected = "a,(b,c),d,(e,f)"
+        )
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TagConverterTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TagConverterTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.tag
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TagConverterTest {
+    @Test
+    fun `It fulfils TagConverter`() {
+        val converter: Any = TagConverter
+        assertTrue(converter is TaggingContract.Converter)
+    }
+
+    @Test
+    fun `Given, convertToTagMap is called with a List of Strings, it converts them into a list and deserializes the key and string`() {
+        // Given
+        val serializesTags = listOf(
+            "potato=bread",
+            "tomato=soup"
+        )
+
+        val expected = hashMapOf(
+            "potato" to "bread",
+            "tomato" to "soup"
+        )
+
+        // When
+        val tags = TagConverter.toTags(serializesTags)
+
+        // Then
+        assertEquals(
+            expected,
+            tags
+        )
+    }
+
+    @Test
+    fun `Given convertToTagMap is called with a empty List, it returns a empty Map`() {
+        // Given
+        val serializesTags = listOf<String>()
+
+        // When
+        val result = TagConverter.toTags(serializesTags)
+
+        // Then
+        assertTrue(result.isEmpty())
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TagConverterTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TagConverterTest.kt
@@ -45,8 +45,8 @@ class TagConverterTest {
 
         // Then
         assertEquals(
-            expected,
-            tags
+            expected = expected,
+            actual = tags
         )
     }
 

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TagEncodingTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TagEncodingTest.kt
@@ -22,46 +22,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class TagCryptoHelperTest {
+class TagEncodingTest {
     @Test
-    fun `It fulfils the Helper`() {
-        val helper: Any = TagCryptoHelper
-        assertTrue(helper is TaggingContract.Helper)
-    }
-
-    @Test
-    fun `Given, convertToTagMap is called with a List of Strings, it converts them into a list and deserializes the key and string`() {
-        // Given
-        val serializesTags = listOf(
-            "potato=bread",
-            "tomato=soup"
-        )
-
-        val expected = hashMapOf(
-            "potato" to "bread",
-            "tomato" to "soup"
-        )
-
-        // When
-        val tags = TagCryptoHelper.convertToTagMap(serializesTags)
-
-        // Then
-        assertEquals(
-            expected,
-            tags
-        )
-    }
-
-    @Test
-    fun `Given convertToTagMap is called with a empty List, it returns a empty Map`() {
-        // Given
-        val serializesTags = listOf<String>()
-
-        // When
-        val result = TagCryptoHelper.convertToTagMap(serializesTags)
-
-        // Then
-        assertTrue(result.isEmpty())
+    fun `It fulfils the Encoding`() {
+        val helper: Any = TagEncoding
+        assertTrue(helper is TaggingContract.Encoding)
     }
 
     @Test
@@ -70,7 +35,7 @@ class TagCryptoHelperTest {
         val tag = " "
 
         // When
-        val exception = assertFailsWith<D4LException> { TagCryptoHelper.encode(tag) }
+        val exception = assertFailsWith<D4LException> { TagEncoding.encode(tag) }
 
         assertTrue(exception is DataValidationException.AnnotationViolation)
         assertEquals(
@@ -85,7 +50,7 @@ class TagCryptoHelperTest {
         val tag = "tag"
 
         // When
-        val result = TagCryptoHelper.encode(tag)
+        val result = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
@@ -100,7 +65,7 @@ class TagCryptoHelperTest {
         val expected = "tag"
 
         // When
-        val result = TagCryptoHelper.encode("  $expected   ")
+        val result = TagEncoding.encode("  $expected   ")
 
         // Then
         assertEquals(
@@ -115,7 +80,7 @@ class TagCryptoHelperTest {
         val expected = "TAG"
 
         // When
-        val result = TagCryptoHelper.encode(expected)
+        val result = TagEncoding.encode(expected)
 
         // Then
         assertEquals(
@@ -130,7 +95,7 @@ class TagCryptoHelperTest {
         val tag = "你好，世界"
 
         // When
-        val result = TagCryptoHelper.encode(tag)
+        val result = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
@@ -145,7 +110,7 @@ class TagCryptoHelperTest {
         val tag = "! '()*-_.~"
 
         // When
-        val result = TagCryptoHelper.encode(tag)
+        val result = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
@@ -160,7 +125,7 @@ class TagCryptoHelperTest {
         val tag = "你好! world."
 
         // When
-        val result = TagCryptoHelper.encode(tag)
+        val result = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
@@ -175,7 +140,7 @@ class TagCryptoHelperTest {
         val encodedTag = "%e4%bd%a0%e5%a5%bd%ef%bc%8c%e4%b8%96%e7%95%8c"
 
         // When
-        val result = TagCryptoHelper.decode(encodedTag)
+        val result = TagEncoding.decode(encodedTag)
 
         // Then
         assertEquals(
@@ -190,7 +155,7 @@ class TagCryptoHelperTest {
         val tag = " "
 
         // When
-        val exception = assertFailsWith<D4LException> { TagCryptoHelper.normalize(tag) }
+        val exception = assertFailsWith<D4LException> { TagEncoding.normalize(tag) }
 
         // Then
         assertTrue(exception is DataValidationException.AnnotationViolation)
@@ -206,7 +171,7 @@ class TagCryptoHelperTest {
         val tag = "tag"
 
         // When
-        val result = TagCryptoHelper.normalize(tag)
+        val result = TagEncoding.normalize(tag)
 
         // Then
         assertEquals(
@@ -221,7 +186,7 @@ class TagCryptoHelperTest {
         val expected = "tag"
 
         // When
-        val result = TagCryptoHelper.normalize("  $expected   ")
+        val result = TagEncoding.normalize("  $expected   ")
 
         // Then
         assertEquals(
@@ -236,7 +201,7 @@ class TagCryptoHelperTest {
         val expected = "TAG"
 
         // When
-        val result = TagCryptoHelper.normalize(expected)
+        val result = TagEncoding.normalize(expected)
 
         // Then
         assertEquals(
@@ -251,7 +216,7 @@ class TagCryptoHelperTest {
         val encodedTag = "%21%27%28%29%2a%2d%5f%2e%7e%20"
 
         // When
-        val result = TagCryptoHelper.decode(encodedTag)
+        val result = TagEncoding.decode(encodedTag)
 
         // Then
         assertEquals(
@@ -266,7 +231,7 @@ class TagCryptoHelperTest {
         val encodedTag = "%e4%bd%a0%e5%a5%bd%21%20world%2e"
 
         // When
-        val result = TagCryptoHelper.decode(encodedTag)
+        val result = TagEncoding.decode(encodedTag)
 
         // Then
         assertEquals(

--- a/sdk-core/src/test/java/care/data4life/sdk/tag/TagEncodingTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/tag/TagEncodingTest.kt
@@ -25,8 +25,8 @@ import kotlin.test.assertTrue
 class TagEncodingTest {
     @Test
     fun `It fulfils the Encoding`() {
-        val helper: Any = TagEncoding
-        assertTrue(helper is TaggingContract.Encoding)
+        val encoding: Any = TagEncoding
+        assertTrue(encoding is TaggingContract.Encoding)
     }
 
     @Test
@@ -39,8 +39,8 @@ class TagEncodingTest {
 
         assertTrue(exception is DataValidationException.AnnotationViolation)
         assertEquals(
-            "Annotation is empty.",
-            exception.message
+            expected = "Annotation is empty.",
+            actual = exception.message
         )
     }
 
@@ -50,12 +50,12 @@ class TagEncodingTest {
         val tag = "tag"
 
         // When
-        val result = TagEncoding.encode(tag)
+        val encoded = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
-            tag,
-            result
+            expected = tag,
+            actual = encoded
         )
     }
 
@@ -65,12 +65,12 @@ class TagEncodingTest {
         val expected = "tag"
 
         // When
-        val result = TagEncoding.encode("  $expected   ")
+        val encoded = TagEncoding.encode("  $expected   ")
 
         // Then
         assertEquals(
-            expected,
-            result
+            expected = expected,
+            actual = encoded
         )
     }
 
@@ -80,12 +80,12 @@ class TagEncodingTest {
         val expected = "TAG"
 
         // When
-        val result = TagEncoding.encode(expected)
+        val encoded = TagEncoding.encode(expected)
 
         // Then
         assertEquals(
-            "tag",
-            result
+            expected = "tag",
+            actual = encoded
         )
     }
 
@@ -95,12 +95,12 @@ class TagEncodingTest {
         val tag = "你好，世界"
 
         // When
-        val result = TagEncoding.encode(tag)
+        val encoded = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
-            "%e4%bd%a0%e5%a5%bd%ef%bc%8c%e4%b8%96%e7%95%8c",
-            result
+            expected = "%e4%bd%a0%e5%a5%bd%ef%bc%8c%e4%b8%96%e7%95%8c",
+            actual = encoded
         )
     }
 
@@ -110,12 +110,12 @@ class TagEncodingTest {
         val tag = "! '()*-_.~"
 
         // When
-        val result = TagEncoding.encode(tag)
+        val encoded = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
-            "%21%20%27%28%29%2a%2d%5f%2e%7e",
-            result
+            expected = "%21%20%27%28%29%2a%2d%5f%2e%7e",
+            actual = encoded
         )
     }
 
@@ -125,12 +125,12 @@ class TagEncodingTest {
         val tag = "你好! world."
 
         // When
-        val result = TagEncoding.encode(tag)
+        val encoded = TagEncoding.encode(tag)
 
         // Then
         assertEquals(
-            "%e4%bd%a0%e5%a5%bd%21%20world%2e",
-            result
+            expected = "%e4%bd%a0%e5%a5%bd%21%20world%2e",
+            actual = encoded
         )
     }
 
@@ -140,12 +140,42 @@ class TagEncodingTest {
         val encodedTag = "%e4%bd%a0%e5%a5%bd%ef%bc%8c%e4%b8%96%e7%95%8c"
 
         // When
-        val result = TagEncoding.decode(encodedTag)
+        val decoded = TagEncoding.decode(encodedTag)
 
         // Then
         assertEquals(
-            "你好，世界",
-            result
+            expected = "你好，世界",
+            actual = decoded
+        )
+    }
+
+    @Test
+    fun `Given, decode is called with a encoded String, which contains special chars, it decodes it`() {
+        // Given
+        val encodedTag = "%21%27%28%29%2a%2d%5f%2e%7e%20"
+
+        // When
+        val decoded = TagEncoding.decode(encodedTag)
+
+        // Then
+        assertEquals(
+            expected = "!'()*-_.~ ",
+            actual = decoded
+        )
+    }
+
+    @Test
+    fun `Given, decode is called with a encoded String, which contains mixed chars, it decodes it`() {
+        // Given
+        val encodedTag = "%e4%bd%a0%e5%a5%bd%21%20world%2e"
+
+        // When
+        val decoded = TagEncoding.decode(encodedTag)
+
+        // Then
+        assertEquals(
+            expected = "你好! world.",
+            actual = decoded
         )
     }
 
@@ -160,8 +190,8 @@ class TagEncodingTest {
         // Then
         assertTrue(exception is DataValidationException.AnnotationViolation)
         assertEquals(
-            exception.message,
-            "Annotation is empty."
+            expected = exception.message,
+            actual = "Annotation is empty."
         )
     }
 
@@ -171,12 +201,12 @@ class TagEncodingTest {
         val tag = "tag"
 
         // When
-        val result = TagEncoding.normalize(tag)
+        val normalized = TagEncoding.normalize(tag)
 
         // Then
         assertEquals(
-            tag,
-            result
+            expected = tag,
+            actual = normalized
         )
     }
 
@@ -186,12 +216,12 @@ class TagEncodingTest {
         val expected = "tag"
 
         // When
-        val result = TagEncoding.normalize("  $expected   ")
+        val normalized = TagEncoding.normalize("  $expected   ")
 
         // Then
         assertEquals(
-            expected,
-            result
+            expected = expected,
+            actual = normalized
         )
     }
 
@@ -201,42 +231,12 @@ class TagEncodingTest {
         val expected = "TAG"
 
         // When
-        val result = TagEncoding.normalize(expected)
+        val normalized = TagEncoding.normalize(expected)
 
         // Then
         assertEquals(
-            "tag",
-            result
-        )
-    }
-
-    @Test
-    fun `Given, decode is called with a encoded String, which contains special chars, it decodes it`() {
-        // Given
-        val encodedTag = "%21%27%28%29%2a%2d%5f%2e%7e%20"
-
-        // When
-        val result = TagEncoding.decode(encodedTag)
-
-        // Then
-        assertEquals(
-            "!'()*-_.~ ",
-            result
-        )
-    }
-
-    @Test
-    fun `Given, decode is called with a encoded String, which contains mixed chars, it decodes it`() {
-        // Given
-        val encodedTag = "%e4%bd%a0%e5%a5%bd%21%20world%2e"
-
-        // When
-        val result = TagEncoding.decode(encodedTag)
-
-        // Then
-        assertEquals(
-            "你好! world.",
-            result
+            expected = "tag",
+            actual = normalized
         )
     }
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/test/util/GenericTestDataProvider.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/test/util/GenericTestDataProvider.kt
@@ -51,7 +51,9 @@ object GenericTestDataProvider {
 
     const val RECORD_ID = "recordId"
 
-    const val RECORD_ID_COMPATIBILITY = "otherRecordId"
+    const val RECORD_ID_LEGACY_KMP = "kmpRecordId"
+
+    const val RECORD_ID_LEGACY_JS = "jsRecordId"
 
     const val USER_ID = "userId"
 

--- a/sdk-core/src/test/java/care/data4life/sdk/test/util/JSLegacyTagConverter.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/test/util/JSLegacyTagConverter.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.test.util
+
+import care.data4life.sdk.migration.MigrationContract.CompatibilityEncoder.Companion.JS_LEGACY_ENCODING_EXCEPTIONS
+import java.util.Locale
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+object JSLegacyTagConverter {
+    private val JS_LEGACY_ENCODING = Pattern.compile("(%[0-9][a-z])|(%[a-z][0-9])|(%[a-z][a-z])")
+
+    private fun filterEncodings(rawEncodings: List<String>): Set<String> {
+        return rawEncodings
+            .filter { encoding -> encoding !in JS_LEGACY_ENCODING_EXCEPTIONS.values }
+            .toSet()
+    }
+
+    private fun convertEncodings(rawEncodings: List<String>, tag: String): String {
+        val cleanedEncodings = filterEncodings(rawEncodings)
+        var alignedTag = tag
+
+        cleanedEncodings.forEach { encoding ->
+            alignedTag = alignedTag.replace(encoding, encoding.toUpperCase(Locale.US))
+        }
+
+        return alignedTag
+    }
+
+    private fun makeJSLegacyEncoding(matcher: Matcher, tag: String): String {
+        val encodings: MutableList<String> = mutableListOf()
+        do {
+            encodings.add(matcher.group())
+        } while (matcher.find())
+
+        return convertEncodings(encodings, tag)
+    }
+
+    fun convertTag(tag: String): String {
+        val matches = JS_LEGACY_ENCODING.matcher(tag)
+
+        return if (matches.find()) makeJSLegacyEncoding(matches, tag) else tag
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/test/util/JSLegacyTagConverter.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/test/util/JSLegacyTagConverter.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.sdk.test.util
 
-import care.data4life.sdk.migration.MigrationContract.CompatibilityEncoder.Companion.JS_LEGACY_ENCODING_EXCEPTIONS
+import care.data4life.sdk.migration.MigrationContract.CompatibilityEncoder.Companion.JS_LEGACY_ENCODING_REPLACEMENTS
 import java.util.Locale
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -26,7 +26,7 @@ object JSLegacyTagConverter {
 
     private fun filterEncodings(rawEncodings: List<String>): Set<String> {
         return rawEncodings
-            .filter { encoding -> encoding !in JS_LEGACY_ENCODING_EXCEPTIONS.values }
+            .filter { encoding -> encoding !in JS_LEGACY_ENCODING_REPLACEMENTS.values }
             .toSet()
     }
 

--- a/sdk-core/src/test/java/care/data4life/sdk/test/util/JSLegacyTagConverterTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/test/util/JSLegacyTagConverterTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.test.util
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class JSLegacyTagConverterTest {
+    @Test
+    fun `Given, convertTag is called, with encoded String, which contains no special chars, it reflects the String`() {
+        // Given
+        val payload = "testString"
+
+        // When
+        val actual = JSLegacyTagConverter.convertTag(payload)
+
+        // Then
+        assertEquals(
+            expected = payload,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given, convertTag is called, with encoded String, which contains encoded chars and they are in lowercase and they had been manually implemented in JS, it reflects them`() {
+        // Given
+        val payload = "%2d%5ftest%2a%2eString%7e"
+
+        // When
+        val actual = JSLegacyTagConverter.convertTag(payload)
+
+        // Then
+        assertEquals(
+            expected = payload,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given, convertTag is called, with encoded String, which contains encoded chars and they are in lowercase and they had been not manually implemented in JS, it returns them in uppercase`() {
+        // Given
+        val expected = "js%2C%20%D0%B2%D0%B5%D1%80%D0%BE%D1%8F%D1%82%D0%BD%D0%BE%2C%20%D0%BD%D0%B5%20%D0%BE%D0%B1%D1%80%D0%B0%D1%89%D0%B0%D0%BB%20%D0%B2%D0%BD%D0%B8%D0%BC%D0%B0%D0%BD%D0%B8%D1%8F"
+        val payload = "js%2c%20%d0%b2%d0%b5%d1%80%d0%be%d1%8f%d1%82%d0%bd%d0%be%2c%20%d0%bd%d0%b5%20%d0%be%d0%b1%d1%80%d0%b0%d1%89%d0%b0%d0%bb%20%d0%b2%d0%bd%d0%b8%d0%bc%d0%b0%d0%bd%d0%b8%d1%8f"
+
+        // When
+        val actual = JSLegacyTagConverter.convertTag(payload)
+
+        // Then
+        assertEquals(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given, convertTag is called, with encoded String, which contains mixed encodings, it converts them properly`() {
+        // Given
+        val expected = "%2d%5ftest%2a%2eString%7ejs%2C%20%D0%B2%D0%B5%D1%80%D0%BE%D1%8F%D1%82%D0%BD%D0%BE%2C%2d%5ftest%2a%2eString%7e%20%D0%BD%D0%B5%20%D0%BE%D0%B1%D1%80%D0%B0%D1%89%D0%B0%D0%BB%20%D0%B2%D0%BD%D0%B8%D0%BC%D0%B0%D0%BD%D0%B8%D1%8F%2d%5ftest%2a%2eString%7e"
+        val payload = "%2d%5ftest%2a%2eString%7ejs%2c%20%d0%b2%d0%b5%d1%80%d0%be%d1%8f%d1%82%d0%bd%d0%be%2c%2d%5ftest%2a%2eString%7e%20%d0%bd%d0%b5%20%d0%be%d0%b1%d1%80%d0%b0%d1%89%d0%b0%d0%bb%20%d0%b2%d0%bd%d0%b8%d0%bc%d0%b0%d0%bd%d0%b8%d1%8f%2d%5ftest%2a%2eString%7e"
+
+        // When
+        val actual = JSLegacyTagConverter.convertTag(payload)
+
+        // Then
+        assertEquals(
+            expected = expected,
+            actual = actual
+        )
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/wrapper/URLEncodingTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/wrapper/URLEncodingTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.sdk.wrapper
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class URLEncodingTest {
+    @Test
+    fun `It fulfils URLEncoding`() {
+        val encoding: Any = URLEncoding
+
+        assertTrue(encoding is WrapperContract.URLEncoding)
+    }
+
+    @Test
+    fun `Given encode is called with a String, it ignores ASCII characters`() {
+        // Given
+        val str = "ABCabc"
+
+        // When
+        val encoded = URLEncoding.encode(str)
+
+        // Then
+        assertEquals(
+            expected = str,
+            actual = encoded
+        )
+    }
+
+    @Test
+    fun `Given, encode is called with a String, it encodes it`() {
+        // Given
+        val str = "你好，世界"
+
+        // When
+        val encoded = URLEncoding.encode(str)
+
+        // Then
+        assertEquals(
+            expected = "%E4%BD%A0%E5%A5%BD%EF%BC%8C%E4%B8%96%E7%95%8C",
+            actual = encoded
+        )
+    }
+
+    @Test
+    fun `Given, encode is called with a String, which contains special chars, it encodes it`() {
+        // Given
+        val str = "! '()*-_.~"
+
+        // When
+        val encoded = URLEncoding.encode(str)
+
+        // Then
+        assertEquals(
+            expected = "%21%20%27%28%29%2A%2D%5F%2E%7E",
+            actual = encoded
+        )
+    }
+
+    @Test
+    fun `Given, encode is called with a String, which contains mixed chars, it encodes it`() {
+        // Given
+        val str = "你好! world."
+
+        // When
+        val encoded = URLEncoding.encode(str)
+
+        // Then
+        assertEquals(
+            expected = "%E4%BD%A0%E5%A5%BD%21%20world%2E",
+            actual = encoded
+        )
+    }
+
+    @Test
+    fun `Given, decode is called with a encoded String in lowercase, it decodes it`() {
+        // Given
+        val encodedTag = "%e4%bd%a0%e5%a5%bd%ef%bc%8c%e4%b8%96%e7%95%8c"
+
+        // When
+        val decoded = URLEncoding.decode(encodedTag)
+
+        // Then
+        assertEquals(
+            expected = "你好，世界",
+            actual = decoded
+        )
+    }
+
+    @Test
+    fun `Given, decode is called with a encoded String in uppercase, it decodes it`() {
+        // Given
+        val encodedTag = "%E4%BD%A0%E5%A5%BD%21%20world%2E"
+
+        // When
+        val decoded = URLEncoding.decode(encodedTag)
+
+        // Then
+        assertEquals(
+            expected = "你好! world.",
+            actual = decoded
+        )
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/wrapper/URLEncodingTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/wrapper/URLEncodingTest.kt
@@ -20,12 +20,12 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class URLEncodingTest {
+class UrlEncodingTest {
     @Test
     fun `It fulfils URLEncoding`() {
-        val encoding: Any = URLEncoding
+        val encoding: Any = UrlEncoding
 
-        assertTrue(encoding is WrapperContract.URLEncoding)
+        assertTrue(encoding is WrapperContract.UrlEncoding)
     }
 
     @Test
@@ -34,7 +34,7 @@ class URLEncodingTest {
         val str = "ABCabc"
 
         // When
-        val encoded = URLEncoding.encode(str)
+        val encoded = UrlEncoding.encode(str)
 
         // Then
         assertEquals(
@@ -49,7 +49,7 @@ class URLEncodingTest {
         val str = "你好，世界"
 
         // When
-        val encoded = URLEncoding.encode(str)
+        val encoded = UrlEncoding.encode(str)
 
         // Then
         assertEquals(
@@ -64,7 +64,7 @@ class URLEncodingTest {
         val str = "! '()*-_.~"
 
         // When
-        val encoded = URLEncoding.encode(str)
+        val encoded = UrlEncoding.encode(str)
 
         // Then
         assertEquals(
@@ -79,7 +79,7 @@ class URLEncodingTest {
         val str = "你好! world."
 
         // When
-        val encoded = URLEncoding.encode(str)
+        val encoded = UrlEncoding.encode(str)
 
         // Then
         assertEquals(
@@ -94,7 +94,7 @@ class URLEncodingTest {
         val encodedTag = "%e4%bd%a0%e5%a5%bd%ef%bc%8c%e4%b8%96%e7%95%8c"
 
         // When
-        val decoded = URLEncoding.decode(encodedTag)
+        val decoded = UrlEncoding.decode(encodedTag)
 
         // Then
         assertEquals(
@@ -109,7 +109,7 @@ class URLEncodingTest {
         val encodedTag = "%E4%BD%A0%E5%A5%BD%21%20world%2E"
 
         // When
-        val decoded = URLEncoding.decode(encodedTag)
+        val decoded = UrlEncoding.decode(encodedTag)
 
         // Then
         assertEquals(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This concludes the actual Tagging compatibly series.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently KMP is not able to see legacy JS Records.
This is part of [SDK-572](https://gesundheitscloud.atlassian.net/browse/SDK-572) and succeeds #141.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
This introduces 2 1/2 completely new classes - the SearchTagBuilder, SearchTags (simple data class) and CompatiblyEncoding.
CompatiblyEncoding follows its names and takes care of the actual 3 different encodings.
SearchTagsBuilder is entitled to build the new AND/OR Tag schema in order to make a single API Call.
SearchTags is only a simple Wrapper around the formatted tags.
Alongside the CompatiblyService had been refactored - it now does not longer make the actual API calls. However it is still in charge of controlling the compatibility  Encoding -> Encrypting -> TagFormatting flow.
The RecordService now took back the control of making the actual calls, while resolving the SearchTags via the the CompatibilityService.
Also the Tagging itself got a minor refactoring, in order make this changes more easier to do. It basically slices the former TagCryptoHelper in 2 parts (Encoding and Converter) and wraps the URLEncoder/URLDecoder.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All new classes got unit tests to cover their behaviour. Existing test sets had been altert to match their new behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
