### PR TITLE
[SDK-566] Change resource client tests

### DIFF
--- a/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
+++ b/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
@@ -17,5 +17,5 @@
 package care.data4life.sdk.config
 
 object SDKConfig {
-    const val version: String = "1.11.0-change-ihc-service-SNAPSHOT"
+    const val version: String = "1.12.0-change-resource-client-tests-SNAPSHOT"
 }

--- a/sdk-core/src/test/java/care/data4life/sdk/data/DataRecordClientTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/data/DataRecordClientTest.kt
@@ -16,7 +16,241 @@
 
 package care.data4life.sdk.data
 
-import org.junit.Ignore
+import care.data4life.sdk.SdkContract
+import care.data4life.sdk.auth.AuthContract
+import care.data4life.sdk.call.CallHandler
+import care.data4life.sdk.call.Callback
+import care.data4life.sdk.call.DataRecord
+import care.data4life.sdk.call.Task
+import care.data4life.sdk.record.RecordContract
+import care.data4life.sdk.tag.Annotations
+import care.data4life.sdk.test.util.GenericTestDataProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.reactivex.Completable
+import io.reactivex.Single
+import org.junit.Before
+import org.junit.Test
+import org.threeten.bp.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
-@Ignore
-class DataRecordClientTest
+class DataRecordClientTest {
+    private val recordService: RecordContract.Service = mockk()
+    private val userService: AuthContract.UserService = mockk()
+    private val callHandler: CallHandler = mockk()
+    private lateinit var client: SdkContract.DataRecordClient
+
+    @Before
+    fun setUp() {
+        client = DataRecordClient(
+            userService,
+            recordService,
+            callHandler
+        )
+    }
+
+    @Test
+    fun `Given create is called, with a Resource, Annotations and a Callback it returns the corresponding Task`() {
+        // Given
+        val resource: DataResource = mockk()
+        val annotations: Annotations = mockk()
+        val callback: Callback<DataRecord<DataResource>> = mockk()
+
+        val userId = GenericTestDataProvider.USER_ID
+        val expectedRecord: DataRecord<DataResource> = mockk()
+        val record: Single<DataRecord<DataResource>> = Single.just(expectedRecord)
+        val expected: Task = mockk()
+        val observer = slot<Single<DataRecord<DataResource>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.createRecord(userId, resource, annotations)
+        } returns record
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecord,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.create(resource, annotations, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given update is called, with a RecordId, a Resource, Annotations and a Callback it returns the corresponding Task`() {
+        // Given
+        val resource: DataResource = mockk()
+        val annotations: Annotations = mockk()
+        val callback: Callback<DataRecord<DataResource>> = mockk()
+        val recordId = GenericTestDataProvider.RECORD_ID
+
+        val userId = GenericTestDataProvider.USER_ID
+        val expectedRecord: DataRecord<DataResource> = mockk()
+        val record: Single<DataRecord<DataResource>> = Single.just(expectedRecord)
+        val expected: Task = mockk()
+        val observer = slot<Single<DataRecord<DataResource>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.updateRecord(userId, recordId, resource, annotations)
+        } returns record
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecord,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.update(recordId, resource, annotations, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given fetch is called, with a RecordId and a Callback it returns the corresponding Task`() {
+        // Given
+        val callback: Callback<DataRecord<DataResource>> = mockk()
+        val recordId = GenericTestDataProvider.RECORD_ID
+
+        val userId = GenericTestDataProvider.USER_ID
+        val expectedRecord: DataRecord<DataResource> = mockk()
+        val record: Single<DataRecord<DataResource>> = Single.just(expectedRecord)
+        val expected: Task = mockk()
+        val observer = slot<Single<DataRecord<DataResource>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.fetchDataRecord(userId, recordId)
+        } returns record
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecord,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.fetch(recordId, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given search is called, with a ResourceType, Annotations, a Startdate, a Enddate, Pagesize, Offset and a Callback it returns the corresponding Task`() {
+        // Given
+        val callback: Callback<List<DataRecord<DataResource>>> = mockk()
+        val annotations: Annotations = mockk()
+        val startDate: LocalDate = mockk()
+        val endDate: LocalDate = mockk()
+        val pageSize = 23
+        val offset = 42
+
+        val userId = GenericTestDataProvider.USER_ID
+        val expectedRecords: List<DataRecord<DataResource>> = mockk()
+        val records: Single<List<DataRecord<DataResource>>> = Single.just(expectedRecords)
+        val expected: Task = mockk()
+        val observer = slot<Single<List<DataRecord<DataResource>>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.fetchDataRecords(
+                userId,
+                annotations,
+                startDate,
+                endDate,
+                pageSize,
+                offset
+            )
+        } returns records
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecords,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.search(
+            annotations,
+            startDate,
+            endDate,
+            pageSize,
+            offset,
+            callback
+        )
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given delete is called, with a RecordId and a Callback, it returns the corresponding Task`() {
+        // Given
+        val callback: Callback<Boolean> = mockk()
+
+        val recordId = GenericTestDataProvider.RECORD_ID
+        val userId = GenericTestDataProvider.USER_ID
+        val result = Completable.fromCallable { true }
+        val expected: Task = mockk()
+        val observer = slot<Single<Boolean>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.deleteRecord(userId, recordId)
+        } returns result
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertTrue(observer.captured.blockingGet())
+            expected
+        }
+
+        // When
+        val actual = client.delete(recordId, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+}

--- a/sdk-core/src/test/java/care/data4life/sdk/fhir/FhirRecordClientTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/fhir/FhirRecordClientTest.kt
@@ -35,10 +35,10 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import org.junit.Before
 import org.junit.Test
+import org.threeten.bp.LocalDate
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import org.threeten.bp.LocalDate
 
 class FhirRecordClientTest {
     private val recordService: RecordContract.Service = mockk()

--- a/sdk-core/src/test/java/care/data4life/sdk/fhir/FhirRecordClientTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/fhir/FhirRecordClientTest.kt
@@ -25,14 +25,20 @@ import care.data4life.sdk.call.Task
 import care.data4life.sdk.model.DownloadType
 import care.data4life.sdk.record.RecordContract
 import care.data4life.sdk.tag.Annotations
+import care.data4life.sdk.test.util.GenericTestDataProvider.ATTACHMENT_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.RECORD_ID
+import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.reactivex.Completable
 import io.reactivex.Single
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.threeten.bp.LocalDate
 
 class FhirRecordClientTest {
     private val recordService: RecordContract.Service = mockk()
@@ -50,7 +56,216 @@ class FhirRecordClientTest {
     }
 
     @Test
-    fun `Given count is called, with a resourceType, Annotations and a Callback it returns the corresponding Task`() {
+    fun `Given create is called, with a Resource, Annotations and a Callback it returns the corresponding Task`() {
+        // Given
+        val resource: Fhir4Resource = mockk()
+        val annotations: Annotations = mockk()
+        val callback: Callback<Fhir4Record<Fhir4Resource>> = mockk()
+
+        val userId = USER_ID
+        val expectedRecord: Fhir4Record<Fhir4Resource> = mockk()
+        val record: Single<Fhir4Record<Fhir4Resource>> = Single.just(expectedRecord)
+        val expected: Task = mockk()
+        val observer = slot<Single<Fhir4Record<Fhir4Resource>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.createRecord(userId, resource, annotations)
+        } returns record
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecord,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.create(resource, annotations, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given update is called, with a RecordId, a Resource, Annotations and a Callback it returns the corresponding Task`() {
+        // Given
+        val resource: Fhir4Resource = mockk()
+        val annotations: Annotations = mockk()
+        val callback: Callback<Fhir4Record<Fhir4Resource>> = mockk()
+        val recordId = RECORD_ID
+
+        val userId = USER_ID
+        val expectedRecord: Fhir4Record<Fhir4Resource> = mockk()
+        val record: Single<Fhir4Record<Fhir4Resource>> = Single.just(expectedRecord)
+        val expected: Task = mockk()
+        val observer = slot<Single<Fhir4Record<Fhir4Resource>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.updateRecord(userId, recordId, resource, annotations)
+        } returns record
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecord,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.update(recordId, resource, annotations, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given fetch is called, with a RecordId and a Callback it returns the corresponding Task`() {
+        // Given
+        val callback: Callback<Fhir4Record<Fhir4Resource>> = mockk()
+        val recordId = RECORD_ID
+
+        val userId = USER_ID
+        val expectedRecord: Fhir4Record<Fhir4Resource> = mockk()
+        val record: Single<Fhir4Record<Fhir4Resource>> = Single.just(expectedRecord)
+        val expected: Task = mockk()
+        val observer = slot<Single<Fhir4Record<Fhir4Resource>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.fetchFhir4Record<Fhir4Resource>(userId, recordId)
+        } returns record
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecord,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.fetch(recordId, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given search is called, with a ResourceType, Annotations, a Startdate, a Enddate, Pagesize, Offset and a Callback it returns the corresponding Task`() {
+        // Given
+        val callback: Callback<List<Fhir4Record<Fhir4Resource>>> = mockk()
+        val resourceType = Fhir4Resource::class.java
+        val annotations: Annotations = mockk()
+        val startDate: LocalDate = mockk()
+        val endDate: LocalDate = mockk()
+        val pageSize = 23
+        val offset = 42
+
+        val userId = USER_ID
+        val expectedRecords: List<Fhir4Record<Fhir4Resource>> = mockk()
+        val records: Single<List<Fhir4Record<Fhir4Resource>>> = Single.just(expectedRecords)
+        val expected: Task = mockk()
+        val observer = slot<Single<List<Fhir4Record<Fhir4Resource>>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.fetchFhir4Records(
+                userId,
+                resourceType,
+                annotations,
+                startDate,
+                endDate,
+                pageSize,
+                offset
+            )
+        } returns records
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedRecords,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.search(
+            resourceType,
+            annotations,
+            startDate,
+            endDate,
+            pageSize,
+            offset,
+            callback
+        )
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given download is called, with a RecordId and a Callback, it returns the corresponding Task`() {
+        // Given
+        val callback: Callback<Fhir4Record<Fhir4Resource>> = mockk()
+
+        val recordId = RECORD_ID
+        val userId = USER_ID
+        val record: Fhir4Record<Fhir4Resource> = mockk()
+        val result = Single.just(record)
+        val expected: Task = mockk()
+        val observer = slot<Single<Fhir4Record<Fhir4Resource>>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.downloadFhir4Record<Fhir4Resource>(recordId, userId)
+        } returns result
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = record,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.download(recordId, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
+    fun `Given count is called, with a ResourceType, Annotations and a Callback it returns the corresponding Task`() {
         // Given
         val resourceType = Fhir4Resource::class.java
         val annotations: Annotations = mockk()
@@ -88,34 +303,30 @@ class FhirRecordClientTest {
     }
 
     @Test
-    fun `Given download is called, with a recordId and a Callback, it returns the corresponding Task`() {
+    fun `Given delete is called, with a RecordId and a Callback, it returns the corresponding Task`() {
         // Given
-        val callback: Callback<Fhir4Record<Fhir4Resource>> = mockk()
+        val callback: Callback<Boolean> = mockk()
 
-        val recordId = "Potato"
-        val userId = "Soup"
-        val record: Fhir4Record<Fhir4Resource> = mockk()
-        val result = Single.just(record)
+        val recordId = RECORD_ID
+        val userId = USER_ID
+        val result = Completable.fromCallable { true }
         val expected: Task = mockk()
-        val observer = slot<Single<Fhir4Record<Fhir4Resource>>>()
+        val observer = slot<Single<Boolean>>()
 
         every { userService.finishLogin(true) } returns Single.just(true)
         every { userService.userID } returns Single.just(userId)
         every {
-            recordService.downloadFhir4Record<Fhir4Resource>(recordId, userId)
+            recordService.deleteRecord(userId, recordId)
         } returns result
         every {
             callHandler.executeSingle(capture(observer), callback)
         } answers {
-            assertEquals(
-                expected = record,
-                actual = observer.captured.blockingGet()
-            )
+            assertTrue(observer.captured.blockingGet())
             expected
         }
 
         // When
-        val actual = client.download(recordId, callback)
+        val actual = client.delete(recordId, callback)
 
         // Then
         assertSame(
@@ -129,9 +340,9 @@ class FhirRecordClientTest {
         // Given
         val callback: Callback<Fhir4Attachment> = mockk()
 
-        val recordId = "Potato"
-        val attachmentId = "Tomato"
-        val userId = "Soup"
+        val recordId = RECORD_ID
+        val userId = USER_ID
+        val attachmentId = ATTACHMENT_ID
         val downloadType = DownloadType.Full
         val attachment: Fhir4Attachment = mockk()
         val result = Single.just(attachment)
@@ -168,9 +379,9 @@ class FhirRecordClientTest {
         // Given
         val callback: Callback<List<Fhir4Attachment>> = mockk()
 
-        val recordId = "Potato"
+        val recordId = RECORD_ID
+        val userId = USER_ID
         val attachmentIds: List<String> = mockk()
-        val userId = "Soup"
         val downloadType = DownloadType.Full
         val attachments: List<Fhir4Attachment> = mockk()
         val result = Single.just(attachments)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds new tests for uncovered parts of the Fhir4- and DataResourceClient.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the Fhir4ResourceClient is only partially covered and DataResourceClient is uncovered by tests.
This is part of [SDK-566](https://gesundheitscloud.atlassian.net/browse/SDK-566).

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
New unittests had been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
