### PR TITLE
[SDK-574] Add count for arbitrary data

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,8 @@ toc::[]
 
 === Added
 
+* Enable count for arbitrary data.
+
 === Changed
 
 * ApiService is now in Kotlin.

--- a/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
+++ b/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
@@ -17,5 +17,5 @@
 package care.data4life.sdk.config
 
 object SDKConfig {
-    const val version: String = "1.12.0-change-resource-client-tests-SNAPSHOT"
+    const val version: String = "1.12.0-change-resource-clients-SNAPSHOT"
 }

--- a/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
+++ b/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
@@ -17,5 +17,5 @@
 package care.data4life.sdk.config
 
 object SDKConfig {
-    const val version: String = "1.12.0-change-resource-clients-SNAPSHOT"
+    const val version: String = "1.12.0-add-count-for-arbitrary-data-SNAPSHOT"
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -560,6 +560,12 @@ class RecordService internal constructor(
         annotations: Annotations
     ): Single<Int> = countFhir3Records(Fhir3Resource::class.java, userId, annotations)
 
+    override fun countDataRecords(
+        type: Class<out DataResource>,
+        userId: String,
+        annotations: Annotations
+    ): Single<Int> = _countRecords(type, userId, annotations)
+
     override fun <T : Fhir3Resource> downloadFhir3Record(
         recordId: String,
         userId: String
@@ -1167,7 +1173,7 @@ class RecordService internal constructor(
     fun updateAttachmentMeta(attachment: WrapperContract.Attachment): WrapperContract.Attachment {
         val data = decode(attachment.data!!)
         attachment.size = data.size
-        attachment.hash = AttachmentHasher.hash(data)
+        attachment.hash = attachmentHash.hash(data)
         return attachment
     }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/SdkContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/SdkContract.kt
@@ -231,6 +231,18 @@ interface SdkContract {
         ): Task
 
         /**
+         * Count {@link DataRecord}s
+         *
+         * @param annotations custom annotations added as tags to the record
+         * @param callback    either {@link Callback#onSuccess(Object)} or {@link Callback#onError(D4LException)} will be called
+         * @return {@link Task} which can be used to cancel ongoing operation or to query operation status
+         */
+        fun count(
+            annotations: Annotations,
+            callback: Callback<Int>
+        ): Task
+
+        /**
          * Delete an {@link DataRecord}
          *
          * @param recordId      the id of the record that shall be deleted
@@ -267,10 +279,6 @@ interface SdkContract {
             offset: Int,
             callback: Callback<List<DataRecord<DataResource>>>
         ): Task
-    }
-
-    companion object {
-        const val VERSION = "1.12.0"
     }
 
     /**

--- a/sdk-core/src/main/java/care/data4life/sdk/fhir/Fhir4RecordClient.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/fhir/Fhir4RecordClient.kt
@@ -48,8 +48,7 @@ internal class Fhir4RecordClient(
         resource: T,
         annotations: Annotations,
         callback: Callback<Fhir4Record<T>>
-    ):
-        Task = executeOperationFlow(
+    ): Task = executeOperationFlow(
         { userId -> recordService.createRecord(userId, resource, annotations) },
         callback
     )

--- a/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
@@ -125,10 +125,23 @@ interface RecordContract {
             annotations: Annotations
         ): Single<Int>
 
+        fun countDataRecords(
+            type: Class<out DataResource>,
+            userId: String,
+            annotations: Annotations
+        ): Single<Int>
+
         fun countAllFhir3Records(userId: String, annotations: Annotations): Single<Int>
 
-        fun <T : Fhir3Resource> downloadFhir3Record(recordId: String, userId: String): Single<Record<T>>
-        fun <T : Fhir4Resource> downloadFhir4Record(recordId: String, userId: String): Single<Fhir4Record<T>>
+        fun <T : Fhir3Resource> downloadFhir3Record(
+            recordId: String,
+            userId: String
+        ): Single<Record<T>>
+
+        fun <T : Fhir4Resource> downloadFhir4Record(
+            recordId: String,
+            userId: String
+        ): Single<Fhir4Record<T>>
 
         @Throws(IllegalArgumentException::class)
         fun downloadFhir3Attachment(

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsModuleTest.kt
@@ -20,6 +20,7 @@ import care.data4life.crypto.GCKey
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.attachment.AttachmentService
 import care.data4life.sdk.crypto.CryptoContract
+import care.data4life.sdk.data.DataResource
 import care.data4life.sdk.fhir.ResourceCryptoService
 import care.data4life.sdk.network.NetworkingContract
 import care.data4life.sdk.network.util.SearchTagsBuilder
@@ -31,6 +32,7 @@ import care.data4life.sdk.tag.Tags
 import care.data4life.sdk.test.fake.CryptoServiceFake
 import care.data4life.sdk.test.fake.CryptoServiceIteration
 import care.data4life.sdk.test.util.GenericTestDataProvider.ALIAS
+import care.data4life.sdk.test.util.GenericTestDataProvider.ARBITRARY_DATA_KEY
 import care.data4life.sdk.test.util.GenericTestDataProvider.CLIENT_ID
 import care.data4life.sdk.test.util.GenericTestDataProvider.PARTNER_ID
 import care.data4life.sdk.test.util.GenericTestDataProvider.USER_ID
@@ -98,7 +100,14 @@ class RecordServiceCountRecordsModuleTest {
 
         val searchTags = SearchTagsBuilder.newBuilder()
             .let { flowHelper.buildExpectedTagGroups(it, encodedTags, legacyKMPTags, legacyJSTags) }
-            .let { flowHelper.buildExpectedTagGroups(it, encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations) }
+            .let {
+                flowHelper.buildExpectedTagGroups(
+                    it,
+                    encodedAnnotations,
+                    legacyKMPAnnotations,
+                    legacyJSAnnotations
+                )
+            }
             .seal()
             .tagGroups
 
@@ -117,7 +126,11 @@ class RecordServiceCountRecordsModuleTest {
             tagEncryptionKeyCalls = 1,
             resources = emptyList(),
             tags = flowHelper.mergeTags(encodedTags, legacyKMPTags, legacyJSTags),
-            annotations = flowHelper.mergeTags(encodedAnnotations, legacyKMPAnnotations, legacyJSAnnotations),
+            annotations = flowHelper.mergeTags(
+                encodedAnnotations,
+                legacyKMPAnnotations,
+                legacyJSAnnotations
+            ),
             hashFunction = { value -> flowHelper.md5(value) }
         )
 
@@ -368,6 +381,72 @@ class RecordServiceCountRecordsModuleTest {
         // When
         val result = recordService.countFhir4Records(
             Fhir4Reference::class.java,
+            USER_ID,
+            annotations
+        ).blockingGet()
+
+        // Then
+        assertEquals(
+            expected = 23,
+            actual = result
+        )
+    }
+
+    // Arbitrary Data
+    @Test
+    fun `Given, countDataRecords is called with a type and UserId, it returns the amount of DataRecords`() {
+        // Given
+        val tags = mapOf(
+            "flag" to ARBITRARY_DATA_KEY,
+            "partner" to PARTNER_ID,
+            "client" to CLIENT_ID
+        )
+
+        runFlow(
+            tags = tags,
+            amount = 46
+        )
+
+        // When
+        val result = recordService.countDataRecords(
+            DataResource::class.java,
+            USER_ID,
+            emptyList()
+        ).blockingGet()
+
+        // Then
+        assertEquals(
+            expected = 46,
+            actual = result
+        )
+    }
+
+    @Test
+    fun `Given, countDataRecords is called with a type, UserId and Annotations, it returns the amount of DataRecords`() {
+        // Given
+        val tags = mapOf(
+            "flag" to ARBITRARY_DATA_KEY,
+            "partner" to PARTNER_ID,
+            "client" to CLIENT_ID
+        )
+
+        val annotations = listOf(
+            "wow",
+            "it",
+            "works",
+            "and",
+            "like_a_duracell_häsi"
+        )
+
+        runFlow(
+            tags = tags,
+            annotations = annotations,
+            amount = 23
+        )
+
+        // When
+        val result = recordService.countDataRecords(
+            DataResource::class.java,
             USER_ID,
             annotations
         ).blockingGet()

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCountRecordsTest.kt
@@ -19,6 +19,7 @@ package care.data4life.sdk
 import care.data4life.fhir.stu3.model.Patient
 import care.data4life.sdk.attachment.AttachmentContract
 import care.data4life.sdk.crypto.CryptoContract
+import care.data4life.sdk.data.DataResource
 import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Resource
 import care.data4life.sdk.fhir.FhirContract
@@ -73,6 +74,41 @@ class RecordServiceCountRecordsTest {
                 compatibilityService
             )
         )
+    }
+
+    @Test
+    @Throws(InterruptedException::class, IOException::class)
+    fun `Given, countDataRecords is called with a DataResource, a UserId and Annotations, it returns amount of occurrences`() {
+        // Given
+        val expected = 42
+        val annotations: Annotations = mockk()
+        val searchTags: NetworkingContract.SearchTags = mockk()
+
+        every { taggingService.getTagsFromType(DataResource::class.java as Class<Any>) } returns tags
+        every { compatibilityService.resolveSearchTags(tags, annotations) } returns searchTags
+        every { apiService.countRecords(ALIAS, USER_ID, searchTags) } returns Single.just(expected)
+
+        // When
+        val observer = recordService.countDataRecords(
+            DataResource::class.java,
+            USER_ID,
+            annotations
+        ).test().await()
+
+        // Then
+        val result = observer
+            .assertNoErrors()
+            .assertComplete()
+            .assertValueCount(1)
+            .values()[0]
+
+        assertEquals(
+            expected = expected,
+            actual = result
+        )
+        verify(exactly = 1) { taggingService.getTagsFromType(DataResource::class.java as Class<Any>) }
+        verify(exactly = 1) { compatibilityService.resolveSearchTags(tags, annotations) }
+        verify(exactly = 1) { apiService.countRecords(ALIAS, USER_ID, searchTags) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/data/DataRecordClientTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/data/DataRecordClientTest.kt
@@ -222,6 +222,44 @@ class DataRecordClientTest {
     }
 
     @Test
+    fun `Given count is called, with a ResourceType, Annotations and a Callback it returns the corresponding Task`() {
+        // Given
+        val resourceType = DataResource::class.java
+        val annotations: Annotations = mockk()
+        val callback: Callback<Int> = mockk()
+
+        val userId = "Potato"
+        val expectedAmount = 23
+        val amount = Single.just(23)
+        val expected: Task = mockk()
+        val observer = slot<Single<Int>>()
+
+        every { userService.finishLogin(true) } returns Single.just(true)
+        every { userService.userID } returns Single.just(userId)
+        every {
+            recordService.countDataRecords(resourceType, userId, annotations)
+        } returns amount
+        every {
+            callHandler.executeSingle(capture(observer), callback)
+        } answers {
+            assertEquals(
+                expected = expectedAmount,
+                actual = observer.captured.blockingGet()
+            )
+            expected
+        }
+
+        // When
+        val actual = client.count(annotations, callback)
+
+        // Then
+        assertSame(
+            expected = expected,
+            actual = actual
+        )
+    }
+
+    @Test
     fun `Given delete is called, with a RecordId and a Callback, it returns the corresponding Task`() {
         // Given
         val callback: Callback<Boolean> = mockk()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This enables the count functionality for arbitrary data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently this functionality is missing. This is part of [SDK-574](https://gesundheitscloud.atlassian.net/browse/SDK-574) and depends on #151.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
It enables count for arbitrary data in the RecordService by adding a new alias methods and finally invokes into the DataResourceClient. Alongside the Client had been aligned with the Fhir4ResourceClient since they are structurally not different.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All changes had been covered with new unitttests. Also for the RecordService 2 new module tests had been added to cover up the changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
