### PR TITLE
[SDK-574] Change ResourceCryptoService

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ toc::[]
 === Changed
 
 * ApiService is now in Kotlin.
+* Errors, which occure during encryption or decryption of a resource are now D4LExceptions.
 
 === Removed
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,7 +21,7 @@ toc::[]
 === Changed
 
 * ApiService is now in Kotlin.
-* Errors, which occure during encryption or decryption of a resource are now D4LExceptions.
+* Errors, which occure during encryption or decryption of a resource are now D4LRuntimeExceptions.
 
 === Removed
 

--- a/sdk-android/src/androidTest/java/care/data4life/sdk/fhir/ResourceCryptoServiceInstrumentedTest.java
+++ b/sdk-android/src/androidTest/java/care/data4life/sdk/fhir/ResourceCryptoServiceInstrumentedTest.java
@@ -24,6 +24,9 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import care.data4life.crypto.GCKey;
 import care.data4life.fhir.stu3.model.DocumentReference;
 import care.data4life.fhir.stu3.model.DomainResource;
@@ -38,6 +41,8 @@ import care.data4life.securestore.SecureStore;
 import care.data4life.securestore.SecureStoreCryptor;
 import care.data4life.securestore.SecureStoreStorage;
 
+import static care.data4life.sdk.tag.TaggingContract.TAG_FHIR_VERSION;
+import static care.data4life.sdk.tag.TaggingContract.TAG_RESOURCE_TYPE;
 import static com.google.common.truth.Truth.assertThat;
 
 @Ignore("Ignored until deep copy of fhir resource is implemented")
@@ -67,10 +72,17 @@ public class ResourceCryptoServiceInstrumentedTest {
     public void encryptAndDecryptFhirResource_shouldCompleteWithoutErrors() throws DataRestrictionException.UnsupportedFileType, DataRestrictionException.MaxDataSizeViolation {
         // given
         DocumentReference dummyDocRef = DocumentReferenceFactory.buildDocument();
-
+        Map<String, String> tags = new HashMap<String, String>() {{
+                put(TAG_FHIR_VERSION, FhirContract.FhirVersion.FHIR_3.getVersion());
+                put(TAG_RESOURCE_TYPE, "documentreference");
+        }};
         // when
         String encryptedResource = resourceCryptoService.encryptResource(dataKey, dummyDocRef);
-        DomainResource decryptedResource = resourceCryptoService.decryptResource(dataKey, DocumentReference.resourceType, encryptedResource);
+        DomainResource decryptedResource = resourceCryptoService.decryptResource(
+                dataKey,
+                tags,
+                encryptedResource
+        );
 
         assertThat(decryptedResource).isInstanceOf(DocumentReference.class);
         DocumentReference docRef = (DocumentReference) decryptedResource;

--- a/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
+++ b/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
@@ -17,5 +17,5 @@
 package care.data4life.sdk.config
 
 object SDKConfig {
-    const val version: String = "1.12.0-change-resource-crypto-tests-SNAPSHOT"
+    const val version: String = "1.12.0-change-resource-crypto-service-SNAPSHOT"
 }

--- a/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
+++ b/sdk-core/src-gen/main/java/care/data4life/sdk/config/SDKConfig.kt
@@ -17,6 +17,5 @@
 package care.data4life.sdk.config
 
 object SDKConfig {
-    const val version: String = "1.12.0-add-count-for-arbitrary-data-SNAPSHOT"
-
+    const val version: String = "1.12.0-change-resource-crypto-tests-SNAPSHOT"
 }

--- a/sdk-core/src/main/java/care/data4life/sdk/CryptoService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/CryptoService.kt
@@ -140,9 +140,9 @@ open class CryptoService : CryptoProtocol, CryptoContract.Service {
     override fun encryptSymmetricKey(
         key: GCKey,
         keyType: KeyType,
-        gckey: GCKey
+        gcKey: GCKey
     ): Single<NetworkModelContract.EncryptedKey> {
-        return Single.fromCallable { createKey(KEY_VERSION, keyType, gckey.getKeyBase64()) }
+        return Single.fromCallable { createKey(KEY_VERSION, keyType, gcKey.getKeyBase64()) }
             .map { exchangeKey -> moshi.adapter(ExchangeKey::class.java).toJson(exchangeKey) }
             .flatMap { jsonKey -> encrypt(key, jsonKey.toByteArray()) }
             .map { encryptedKeyBase64 -> EncryptedKey.create(encryptedKeyBase64) }

--- a/sdk-core/src/main/java/care/data4life/sdk/CryptoService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/CryptoService.kt
@@ -192,13 +192,13 @@ open class CryptoService : CryptoProtocol, CryptoContract.Service {
 
     private fun convertExchangeKeyToGCKey(exchangeKey: ExchangeKey): Single<GCKey> {
         return Single.fromCallable { exchangeKey }
-            .map { exchKey ->
-                if (exchKey.getVersion() !== KeyVersion.VERSION_1) {
-                    throw (CryptoException.InvalidKeyVersion(exchKey.getVersion().value))
-                } else if (exchKey.type === KeyType.APP_PUBLIC_KEY || exchKey.type === KeyType.APP_PRIVATE_KEY) {
+            .map { exchangeKey ->
+                if (exchangeKey.getVersion() !== KeyVersion.VERSION_1) {
+                    throw (CryptoException.InvalidKeyVersion(exchangeKey.getVersion().value))
+                } else if (exchangeKey.type === KeyType.APP_PUBLIC_KEY || exchangeKey.type === KeyType.APP_PRIVATE_KEY) {
                     throw (CryptoException.KeyDecryptionFailed("can't decrypt asymmetric to symmetric key"))
                 }
-                keyFactory.createGCKey(exchKey)
+                keyFactory.createGCKey(exchangeKey)
             }
             .onErrorResumeNext { error ->
                 Log.error(error, "Failed to decrypt exchangeKey")

--- a/sdk-core/src/main/java/care/data4life/sdk/CryptoService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/CryptoService.kt
@@ -123,8 +123,8 @@ open class CryptoService : CryptoProtocol, CryptoContract.Service {
             }
     }
 
-    override fun encryptAndEncodeString(key: GCKey, data: String): Single<String> {
-        return encrypt(key, data.toByteArray())
+    override fun encryptAndEncodeByteArray(key: GCKey, data: ByteArray): Single<String> {
+        return encrypt(key, data)
             .map { dataArray -> base64.encodeToString(dataArray) }
             .onErrorResumeNext { error ->
                 Log.error(error, "Failed to encrypt string")
@@ -132,16 +132,10 @@ open class CryptoService : CryptoProtocol, CryptoContract.Service {
             }
     }
 
-    override fun decodeAndDecryptString(key: GCKey, dataBase64: String): Single<String> {
-        return Single
-            .fromCallable { base64.decode(dataBase64) }
-            .flatMap { decoded -> decrypt(key, decoded) }
-            .map { decrypted -> String(decrypted, Charsets.UTF_8) }
-            .onErrorResumeNext { error ->
-                Log.error(error, "Failed to decrypt string")
-                Single.error(CryptoException.DecryptionFailed("Failed to decrypt string") as D4LException)
-            }
-    }
+    override fun encryptAndEncodeString(
+        key: GCKey,
+        data: String
+    ): Single<String> = encryptAndEncodeByteArray(key, data.toByteArray())
 
     override fun encryptSymmetricKey(
         key: GCKey,
@@ -155,6 +149,25 @@ open class CryptoService : CryptoProtocol, CryptoContract.Service {
             .onErrorResumeNext { error ->
                 Log.error(error, "Failed to encrypt GcKey")
                 Single.error(CryptoException.KeyEncryptionFailed("Failed to encrypt GcKey") as D4LException)
+            }
+    }
+
+    override fun decodeAndDecryptString(key: GCKey, dataBase64: String): Single<String> {
+        return decodeAndDecryptByteArray(key, dataBase64)
+            .map { decrypted -> String(decrypted, Charsets.UTF_8) }
+            .onErrorResumeNext { error ->
+                Log.error(error, "Failed to decrypt string")
+                Single.error(CryptoException.DecryptionFailed("Failed to decrypt string") as D4LException)
+            }
+    }
+
+    override fun decodeAndDecryptByteArray(key: GCKey, dataBase64: String): Single<ByteArray> {
+        return Single
+            .fromCallable { base64.decode(dataBase64) }
+            .flatMap { decoded -> decrypt(key, decoded) }
+            .onErrorResumeNext { error ->
+                Log.error(error, "Failed to decrypt string")
+                Single.error(CryptoException.DecryptionFailed("Failed to decrypt string") as D4LException)
             }
     }
 

--- a/sdk-core/src/main/java/care/data4life/sdk/crypto/CryptoContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/crypto/CryptoContract.kt
@@ -62,7 +62,10 @@ class CryptoContract {
         fun encrypt(key: GCKey, data: ByteArray): Single<ByteArray>
         fun decrypt(key: GCKey, data: ByteArray): Single<ByteArray>
 
+        // ToDo move this into a convenience layer
         fun encryptAndEncodeString(key: GCKey, data: String): Single<String>
+
+        // ToDo move this into a convenience layer
         fun encryptAndEncodeByteArray(key: GCKey, data: ByteArray): Single<String>
 
         fun encryptSymmetricKey(
@@ -71,7 +74,10 @@ class CryptoContract {
             gcKey: GCKey
         ): Single<NetworkModelContract.EncryptedKey>
 
+        // ToDo move this into a convenience layer
         fun decodeAndDecryptString(key: GCKey, dataBase64: String): Single<String>
+
+        // ToDo move this into a convenience layer
         fun decodeAndDecryptByteArray(key: GCKey, dataBase64: String): Single<ByteArray>
 
         fun symDecryptSymmetricKey(

--- a/sdk-core/src/main/java/care/data4life/sdk/crypto/CryptoContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/crypto/CryptoContract.kt
@@ -61,14 +61,18 @@ class CryptoContract {
 
         fun encrypt(key: GCKey, data: ByteArray): Single<ByteArray>
         fun decrypt(key: GCKey, data: ByteArray): Single<ByteArray>
-        // TODO Change interface so it Arbitrary Data can use it directly
+
         fun encryptAndEncodeString(key: GCKey, data: String): Single<String>
-        fun decodeAndDecryptString(key: GCKey, dataBase64: String): Single<String>
+        fun encryptAndEncodeByteArray(key: GCKey, data: ByteArray): Single<String>
+
         fun encryptSymmetricKey(
             key: GCKey,
             keyType: KeyType,
-            gckey: GCKey
+            gcKey: GCKey
         ): Single<NetworkModelContract.EncryptedKey>
+
+        fun decodeAndDecryptString(key: GCKey, dataBase64: String): Single<String>
+        fun decodeAndDecryptByteArray(key: GCKey, dataBase64: String): Single<ByteArray>
 
         fun symDecryptSymmetricKey(
             key: GCKey,

--- a/sdk-core/src/main/java/care/data4life/sdk/crypto/CryptoContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/crypto/CryptoContract.kt
@@ -62,10 +62,10 @@ class CryptoContract {
         fun encrypt(key: GCKey, data: ByteArray): Single<ByteArray>
         fun decrypt(key: GCKey, data: ByteArray): Single<ByteArray>
 
-        // ToDo move this into a convenience layer
+        // TODO move this into a convenience layer
         fun encryptAndEncodeString(key: GCKey, data: String): Single<String>
 
-        // ToDo move this into a convenience layer
+        // TODO move this into a convenience layer
         fun encryptAndEncodeByteArray(key: GCKey, data: ByteArray): Single<String>
 
         fun encryptSymmetricKey(
@@ -74,10 +74,10 @@ class CryptoContract {
             gcKey: GCKey
         ): Single<NetworkModelContract.EncryptedKey>
 
-        // ToDo move this into a convenience layer
+        // TODO move this into a convenience layer
         fun decodeAndDecryptString(key: GCKey, dataBase64: String): Single<String>
 
-        // ToDo move this into a convenience layer
+        // TODO move this into a convenience layer
         fun decodeAndDecryptByteArray(key: GCKey, dataBase64: String): Single<ByteArray>
 
         fun symDecryptSymmetricKey(

--- a/sdk-core/src/main/java/care/data4life/sdk/fhir/FhirContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/fhir/FhirContract.kt
@@ -24,7 +24,7 @@ import care.data4life.sdk.tag.Tags
 interface FhirContract {
 
     interface CryptoService {
-        fun _encryptResource(dataKey: GCKey, resource: Any): String
+        fun encryptResource(dataKey: GCKey, resource: Any): String
 
         fun <T : Any> decryptResource(
             dataKey: GCKey,

--- a/sdk-core/src/main/java/care/data4life/sdk/network/model/RecordCryptoService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/network/model/RecordCryptoService.kt
@@ -237,7 +237,7 @@ class RecordCryptoService(
                 decryptedRecord.tags,
                 decryptedRecord.annotations
             ),
-            resourceCryptoService._encryptResource(dataKey, decryptedRecord.resource),
+            resourceCryptoService.encryptResource(dataKey, decryptedRecord.resource),
             decryptedRecord.customCreationDate,
             encryptedDataKey,
             encryptedAttachmentKey,

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/SdkFhirParser.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/SdkFhirParser.kt
@@ -23,7 +23,7 @@ internal object SdkFhirParser : WrapperContract.FhirParser {
         return fhir4Parser.toFhir(clazz!!, source)
     }
 
-    override fun fromResource(resource: Any): String? {
+    override fun fromResource(resource: Any): String {
         return when (resource) {
             is Fhir3Resource -> fhir3Parser.fromFhir(resource)
             is Fhir4Resource -> fhir4Parser.fromFhir(resource)

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/SdkFhirParser.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/SdkFhirParser.kt
@@ -4,6 +4,7 @@ import care.data4life.fhir.Fhir
 import care.data4life.fhir.FhirParser
 import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.CoreRuntimeException
 
 internal object SdkFhirParser : WrapperContract.FhirParser {
@@ -11,13 +12,22 @@ internal object SdkFhirParser : WrapperContract.FhirParser {
     private val fhir4Parser: FhirParser<Any> = Fhir().createR4Parser()
     private val fhirElement: WrapperContract.FhirElementFactory = SdkFhirElementFactory
 
-    override fun toFhir3(resourceType: String, source: String): Fhir3Resource {
+    // ToDo once KMP Fhir is in place replace any by the base fhir type
+    override fun <T : Any> toFhir(resourceType: String, version: String, source: String): T {
+        return when (version) {
+            FhirContract.FhirVersion.FHIR_3.version -> toFhir3(resourceType, source)
+            FhirContract.FhirVersion.FHIR_4.version -> toFhir4(resourceType, source)
+            else -> throw CoreRuntimeException.UnsupportedOperation()
+        } as T
+    }
+
+    private fun toFhir3(resourceType: String, source: String): Fhir3Resource {
         val clazz = fhirElement.getFhir3ClassForType(resourceType)
 
         return fhir3Parser.toFhir(clazz!!, source)
     }
 
-    override fun toFhir4(resourceType: String, source: String): Fhir4Resource {
+    private fun toFhir4(resourceType: String, source: String): Fhir4Resource {
         val clazz = fhirElement.getFhir4ClassForType(resourceType)
 
         return fhir4Parser.toFhir(clazz!!, source)

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
@@ -61,7 +61,7 @@ class WrapperContract {
         fun toFhir4(resourceType: String, source: String): Fhir4Resource?
 
         @Throws(FhirException::class)
-        fun fromResource(resource: Any): String?
+        fun fromResource(resource: Any): String
     }
 
     interface DateTimeFormatter {

--- a/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/wrapper/WrapperContract.kt
@@ -55,10 +55,7 @@ class WrapperContract {
 
     interface FhirParser {
         @Throws(FhirException::class)
-        fun toFhir3(resourceType: String, source: String): Fhir3Resource?
-
-        @Throws(FhirException::class)
-        fun toFhir4(resourceType: String, source: String): Fhir4Resource?
+        fun <T : Any> toFhir(resourceType: String, version: String, source: String): T
 
         @Throws(FhirException::class)
         fun fromResource(resource: Any): String

--- a/sdk-core/src/test/java/care/data4life/sdk/CryptoServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/CryptoServiceTest.kt
@@ -163,7 +163,7 @@ class CryptoServiceTest {
     }
 
     @Test
-    fun encryptString_shouldCompleteWithoutErrors() {
+    fun encryptAndEncodeString_shouldCompleteWithoutErrors() {
         // given
         val input = "data"
 
@@ -178,13 +178,44 @@ class CryptoServiceTest {
     }
 
     @Test
-    fun decryptString_shouldCompleteWithoutErrors() {
+    fun encryptAndEncodeBytes_shouldCompleteWithoutErrors() {
+        // given
+        val input = "data"
+
+        // when
+        val testSubscriber = cryptoService.encryptAndEncodeByteArray(gcKey, input.toByteArray())
+            .test()
+
+        // then
+        testSubscriber
+            .assertNoErrors()
+            .assertComplete()
+    }
+
+    @Test
+    fun decodeAndDecryptString_shouldCompleteWithoutErrors() {
         // given
         val input = "data"
 
         // when
         val testSubscriber = cryptoService
             .decodeAndDecryptString(gcKey, input)
+            .test()
+
+        // then
+        testSubscriber
+            .assertNoErrors()
+            .assertComplete()
+    }
+
+    @Test
+    fun decodeAndDecryptByteArray_shouldCompleteWithoutErrors() {
+        // given
+        val input = "data"
+
+        // when
+        val testSubscriber = cryptoService
+            .decodeAndDecryptByteArray(gcKey, input)
             .test()
 
         // then

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAdditionalResourceTypeModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAdditionalResourceTypeModuleTest.kt
@@ -313,8 +313,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -337,8 +338,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
         // When
@@ -362,9 +364,13 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
-            TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), "$resourceName-nulled-attachment")
+            FhirContract.FhirVersion.FHIR_3.version,
+            TestResourceHelper.getJSONResource(
+                determineFhir3Folder(resourcePrefixes),
+                "$resourceName-nulled-attachment"
+            )
         )
 
         // When
@@ -386,9 +392,13 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
-            TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), "$resourceName-nulled-attachment")
+            FhirContract.FhirVersion.FHIR_4.version,
+            TestResourceHelper.getJSONResource(
+                determineFhir4Folder(resourcePrefixes),
+                "$resourceName-nulled-attachment"
+            )
         )
 
         // When
@@ -403,8 +413,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -443,8 +454,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -480,8 +492,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val originalResource = SdkFhirParser.toFhir3(
+        val originalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -529,8 +542,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val originalResource = SdkFhirParser.toFhir4(
+        val originalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -638,8 +652,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -715,8 +730,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -741,8 +757,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -765,8 +782,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -783,8 +801,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     fun `Given, checkForUnsupportedData is called, with a Fhir3Resource, it fails due to unsupported data`() {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -804,8 +823,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     fun `Given, checkForUnsupportedData is called, with a Fhir4Resource, it fails due to unsupported data`() {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -820,8 +840,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     fun `Given, checkForUnsupportedData is called, with a Fhir3Resource, it fails due  to file size limit breach`() {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -841,8 +862,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
     fun `Given, checkForUnsupportedData is called, with a Fhir4Resource, it fails due  to file size limit breach`() {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -859,8 +881,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -909,7 +932,12 @@ class RecordServiceAdditionalResourceTypeModuleTest {
             modelVersion
         )
 
-        every { recordService.decryptRecord<Fhir3Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            recordService.decryptRecord<Fhir3Resource>(
+                fetchedRecord,
+                USER_ID
+            )
+        } returns decryptedRecord
         every {
             apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
         } returns Single.just(fetchedRecord)
@@ -959,8 +987,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -1064,8 +1093,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -1114,7 +1144,12 @@ class RecordServiceAdditionalResourceTypeModuleTest {
             modelVersion
         )
 
-        every { recordService.decryptRecord<Fhir4Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            recordService.decryptRecord<Fhir4Resource>(
+                fetchedRecord,
+                USER_ID
+            )
+        } returns decryptedRecord
         every {
             apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
         } returns Single.just(fetchedRecord)
@@ -1154,8 +1189,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -1204,7 +1240,12 @@ class RecordServiceAdditionalResourceTypeModuleTest {
             modelVersion
         )
 
-        every { recordService.decryptRecord<Fhir4Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            recordService.decryptRecord<Fhir4Resource>(
+                fetchedRecord,
+                USER_ID
+            )
+        } returns decryptedRecord
         every {
             apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
         } returns Single.just(fetchedRecord)
@@ -1254,8 +1295,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir4") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             TestResourceHelper.getJSONResource(determineFhir4Folder(resourcePrefixes), resourceName)
         )
 
@@ -1359,8 +1401,9 @@ class RecordServiceAdditionalResourceTypeModuleTest {
         Assume.assumeTrue(resourcePrefixes.contains("fhir3") || resourcePrefixes.contains("common"))
 
         // Given
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             TestResourceHelper.getJSONResource(determineFhir3Folder(resourcePrefixes), resourceName)
         )
 
@@ -1409,7 +1452,12 @@ class RecordServiceAdditionalResourceTypeModuleTest {
             modelVersion
         )
 
-        every { recordService.decryptRecord<Fhir3Resource>(fetchedRecord, USER_ID) } returns decryptedRecord
+        every {
+            recordService.decryptRecord<Fhir3Resource>(
+                fetchedRecord,
+                USER_ID
+            )
+        } returns decryptedRecord
         every {
             apiService.fetchRecord(ALIAS, USER_ID, RECORD_ID)
         } returns Single.just(fetchedRecord)

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUtilsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentUtilsTest.kt
@@ -520,7 +520,11 @@ class RecordServiceAttachmentUtilsTest {
             "s4h-patient-example.patient"
         )
 
-        val doc = SdkFhirParser.toFhir4("Patient", resourceStr)
+        val doc = SdkFhirParser.toFhir<Fhir4Resource>(
+            "Patient",
+            FhirContract.FhirVersion.FHIR_4.version,
+            resourceStr
+        )
 
         // When
         recordService.checkDataRestrictions(doc)

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCreationRecordModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCreationRecordModuleTest.kt
@@ -150,6 +150,8 @@ class RecordServiceCreationRecordModuleTest {
                     (cryptoService as CryptoServiceFake).iteration = receivedIteration
                 }
             } else {
+
+                println(encryptedUploadRecord)
                 throw RuntimeException("Unexpected encrypted record\n${actualRecord.captured}")
             }
         }
@@ -245,7 +247,7 @@ class RecordServiceCreationRecordModuleTest {
         val encodedTags = flowHelper.prepareTags(tags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedUploadRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedUploadRecord = flowHelper.prepareEncryptedRecord(
             null,
             serializedResource,
             encodedTags,
@@ -292,7 +294,7 @@ class RecordServiceCreationRecordModuleTest {
         val encodedTags = flowHelper.prepareTags(tags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedUploadRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedUploadRecord = flowHelper.prepareEncryptedRecord(
             null,
             serializedResource,
             encodedTags,
@@ -345,7 +347,7 @@ class RecordServiceCreationRecordModuleTest {
         val encodedTags = flowHelper.prepareTags(tags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedUploadRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedUploadRecord = flowHelper.prepareEncryptedRecord(
             null,
             serializedResource,
             encodedTags,

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCreationRecordModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceCreationRecordModuleTest.kt
@@ -26,7 +26,10 @@ import care.data4life.sdk.config.DataRestrictionException
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.data.DataResource
 import care.data4life.sdk.fhir.Fhir3Identifier
+import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Identifier
+import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.fhir.ResourceCryptoService
 import care.data4life.sdk.model.Record
 import care.data4life.sdk.network.NetworkingContract
@@ -394,13 +397,14 @@ class RecordServiceCreationRecordModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         runFhirFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags,
             useStoredCommonKey = false
         )
@@ -452,13 +456,14 @@ class RecordServiceCreationRecordModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         runFhirFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags,
             annotations = annotations
         )
@@ -519,13 +524,15 @@ class RecordServiceCreationRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -540,7 +547,7 @@ class RecordServiceCreationRecordModuleTest {
         internalResource.content[0].attachment.data = null
 
         runFhirFlowWithAttachment(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             attachmentData = rawAttachment,
             tags = tags,
             annotations = annotations,
@@ -619,13 +626,15 @@ class RecordServiceCreationRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -643,7 +652,7 @@ class RecordServiceCreationRecordModuleTest {
         val thumbnail = Pair(THUMBNAIL, THUMBNAIL_ID)
 
         runFhirFlowWithAttachment(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             attachmentData = rawAttachment,
             tags = tags,
             annotations = annotations,
@@ -724,13 +733,14 @@ class RecordServiceCreationRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         runFhirFlowWithAttachment(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             attachmentData = rawAttachment,
             tags = tags,
             annotations = annotations,
@@ -767,13 +777,14 @@ class RecordServiceCreationRecordModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         runFhirFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags,
             useStoredCommonKey = false
         )
@@ -825,13 +836,14 @@ class RecordServiceCreationRecordModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         runFhirFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags,
             annotations = annotations
         )
@@ -892,13 +904,15 @@ class RecordServiceCreationRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
@@ -914,7 +928,7 @@ class RecordServiceCreationRecordModuleTest {
         internalResource.content[0].attachment.data = null
 
         runFhirFlowWithAttachment(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             attachmentData = rawAttachment,
             tags = tags,
             annotations = annotations,
@@ -993,13 +1007,15 @@ class RecordServiceCreationRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
@@ -1018,7 +1034,7 @@ class RecordServiceCreationRecordModuleTest {
         val thumbnail = Pair(ByteArray(1), THUMBNAIL_ID)
 
         runFhirFlowWithAttachment(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             attachmentData = rawAttachment,
             tags = tags,
             annotations = annotations,
@@ -1099,13 +1115,14 @@ class RecordServiceCreationRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         runFhirFlowWithAttachment(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             attachmentData = rawAttachment,
             tags = tags,
             annotations = annotations,

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceDownloadAttachmentAndRecordModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceDownloadAttachmentAndRecordModuleTest.kt
@@ -134,7 +134,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             useStoredCommonKey
         )
 
-        val encryptedRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResource,
             encodedTags,

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceDownloadAttachmentAndRecordModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceDownloadAttachmentAndRecordModuleTest.kt
@@ -23,7 +23,10 @@ import care.data4life.sdk.attachment.FileService
 import care.data4life.sdk.call.Fhir4Record
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.fhir.Fhir3Identifier
+import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Identifier
+import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.fhir.ResourceCryptoService
 import care.data4life.sdk.model.DownloadType
 import care.data4life.sdk.model.Record
@@ -210,8 +213,9 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -228,7 +232,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID
@@ -273,8 +277,9 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -290,7 +295,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
         internalResource.content[0].attachment.hash = Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID
@@ -333,8 +338,9 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
@@ -350,7 +356,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
         internalResource.content[0].attachment.hash = Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID
@@ -395,8 +401,9 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -413,7 +420,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID
@@ -457,13 +464,15 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -491,7 +500,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID
@@ -557,13 +566,14 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID
@@ -603,13 +613,15 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
@@ -635,7 +647,7 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
         internalResource.content[0].attachment.hash = Base64.encodeToString(HashUtil.sha1(String(rawAttachment).toByteArray()))
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID
@@ -701,13 +713,14 @@ class RecordServiceDownloadAttachmentAndRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         runAttachmentDownloadFlow(
-            serializedResource = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResource = SdkFhirParser.fromResource(internalResource),
             rawAttachment = rawAttachment,
             tags = tags,
             attachmentId = ATTACHMENT_ID

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsModuleTest.kt
@@ -175,7 +175,7 @@ class RecordServiceFetchRecordsModuleTest {
         val encodedTags = flowHelper.prepareTags(tags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResource,
             encodedTags,
@@ -221,7 +221,7 @@ class RecordServiceFetchRecordsModuleTest {
         val encodedTags = flowHelper.prepareTags(tags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResource,
             encodedTags,
@@ -355,7 +355,7 @@ class RecordServiceFetchRecordsModuleTest {
             .seal()
             .tagGroups
 
-        val encryptedRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedRecord = flowHelper.prepareEncryptedRecord(
             recordIds.first,
             serializedResources.first,
             encodedTags,
@@ -367,7 +367,7 @@ class RecordServiceFetchRecordsModuleTest {
             updateDate
         )
 
-        val encryptedKMPLegacyRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedKMPLegacyRecord = flowHelper.prepareEncryptedRecord(
             recordIds.second,
             serializedResources.second,
             legacyKMPTags,
@@ -379,7 +379,7 @@ class RecordServiceFetchRecordsModuleTest {
             updateDate
         )
 
-        val encryptedJSLegacyRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedJSLegacyRecord = flowHelper.prepareEncryptedRecord(
             recordIds.third,
             serializedResources.third,
             legacyJSTags,
@@ -442,7 +442,7 @@ class RecordServiceFetchRecordsModuleTest {
             .seal()
             .tagGroups
 
-        val encryptedRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedRecord = flowHelper.prepareEncryptedRecord(
             recordIds.first,
             serializedResources.first,
             encodedTags,
@@ -454,7 +454,7 @@ class RecordServiceFetchRecordsModuleTest {
             updateDate
         )
 
-        val encryptedKMPLegacyRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedKMPLegacyRecord = flowHelper.prepareEncryptedRecord(
             recordIds.second,
             serializedResources.second,
             legacyKMPTags,
@@ -466,7 +466,7 @@ class RecordServiceFetchRecordsModuleTest {
             updateDate
         )
 
-        val encryptedJSLegacyRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedJSLegacyRecord = flowHelper.prepareEncryptedRecord(
             recordIds.third,
             serializedResources.third,
             legacyJSTags,

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceFetchRecordsModuleTest.kt
@@ -22,6 +22,9 @@ import care.data4life.sdk.attachment.AttachmentService
 import care.data4life.sdk.call.DataRecord
 import care.data4life.sdk.call.Fhir4Record
 import care.data4life.sdk.crypto.CryptoContract
+import care.data4life.sdk.fhir.Fhir3Resource
+import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.fhir.ResourceCryptoService
 import care.data4life.sdk.model.Record
 import care.data4life.sdk.network.NetworkingContract
@@ -519,13 +522,14 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         runFhirFetchFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags
         )
 
@@ -574,13 +578,14 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         runFhirFetchFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags,
             annotations = annotations,
             useStoredCommonKey = false
@@ -627,13 +632,14 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         runFhirFetchFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags
         )
 
@@ -682,13 +688,14 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         runFhirFetchFlow(
-            serializedResource = SdkFhirParser.fromResource(resource)!!,
+            serializedResource = SdkFhirParser.fromResource(resource),
             tags = tags,
             annotations = annotations,
             useStoredCommonKey = false
@@ -832,18 +839,21 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val legacyKMPResource = SdkFhirParser.toFhir3(
+        val legacyKMPResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template2
         ) as Fhir3DocumentReference
 
-        val legacyJSResource = SdkFhirParser.toFhir3(
+        val legacyJSResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template3
         ) as Fhir3DocumentReference
 
@@ -852,9 +862,9 @@ class RecordServiceFetchRecordsModuleTest {
 
         runFhirBatchFlow(
             serializedResources = Triple(
-                SdkFhirParser.fromResource(resource)!!,
-                SdkFhirParser.fromResource(legacyKMPResource)!!,
-                SdkFhirParser.fromResource(legacyJSResource)!!
+                SdkFhirParser.fromResource(resource),
+                SdkFhirParser.fromResource(legacyKMPResource),
+                SdkFhirParser.fromResource(legacyJSResource)
             ),
             tags = tags,
             useStoredCommonKey = false
@@ -933,18 +943,21 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val legacyKMPResource = SdkFhirParser.toFhir3(
+        val legacyKMPResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template2
         ) as Fhir3DocumentReference
 
-        val legacyJSResource = SdkFhirParser.toFhir3(
+        val legacyJSResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template3
         ) as Fhir3DocumentReference
 
@@ -953,9 +966,9 @@ class RecordServiceFetchRecordsModuleTest {
 
         runFhirBatchFlow(
             serializedResources = Triple(
-                SdkFhirParser.fromResource(resource)!!,
-                SdkFhirParser.fromResource(legacyKMPResource)!!,
-                SdkFhirParser.fromResource(legacyJSResource)!!
+                SdkFhirParser.fromResource(resource),
+                SdkFhirParser.fromResource(legacyKMPResource),
+                SdkFhirParser.fromResource(legacyJSResource)
             ),
             tags = tags,
             annotations = annotations
@@ -1046,18 +1059,21 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir3(
+        val resource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val legacyKMPResource = SdkFhirParser.toFhir3(
+        val legacyKMPResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template2
         ) as Fhir3DocumentReference
 
-        val legacyJSResource = SdkFhirParser.toFhir3(
+        val legacyJSResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template3
         ) as Fhir3DocumentReference
 
@@ -1066,9 +1082,9 @@ class RecordServiceFetchRecordsModuleTest {
 
         runFhirBatchFlow(
             serializedResources = Triple(
-                SdkFhirParser.fromResource(resource)!!,
-                SdkFhirParser.fromResource(legacyKMPResource)!!,
-                SdkFhirParser.fromResource(legacyJSResource)!!,
+                SdkFhirParser.fromResource(resource),
+                SdkFhirParser.fromResource(legacyKMPResource),
+                SdkFhirParser.fromResource(legacyJSResource),
             ),
             tags = tags,
             annotations = annotations,
@@ -1152,18 +1168,21 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val legacyKMPResource = SdkFhirParser.toFhir4(
+        val legacyKMPResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template2
         ) as Fhir4DocumentReference
 
-        val legacyJSResource = SdkFhirParser.toFhir4(
+        val legacyJSResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template3
         ) as Fhir4DocumentReference
 
@@ -1172,9 +1191,9 @@ class RecordServiceFetchRecordsModuleTest {
 
         runFhirBatchFlow(
             serializedResources = Triple(
-                SdkFhirParser.fromResource(resource)!!,
-                SdkFhirParser.fromResource(legacyKMPResource)!!,
-                SdkFhirParser.fromResource(legacyJSResource)!!
+                SdkFhirParser.fromResource(resource),
+                SdkFhirParser.fromResource(legacyKMPResource),
+                SdkFhirParser.fromResource(legacyJSResource)
             ),
             tags = tags,
             useStoredCommonKey = false
@@ -1253,18 +1272,21 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val legacyKMPResource = SdkFhirParser.toFhir4(
+        val legacyKMPResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template2
         ) as Fhir4DocumentReference
 
-        val legacyJSResource = SdkFhirParser.toFhir4(
+        val legacyJSResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template3
         ) as Fhir4DocumentReference
 
@@ -1273,9 +1295,9 @@ class RecordServiceFetchRecordsModuleTest {
 
         runFhirBatchFlow(
             serializedResources = Triple(
-                SdkFhirParser.fromResource(resource)!!,
-                SdkFhirParser.fromResource(legacyKMPResource)!!,
-                SdkFhirParser.fromResource(legacyJSResource)!!
+                SdkFhirParser.fromResource(resource),
+                SdkFhirParser.fromResource(legacyKMPResource),
+                SdkFhirParser.fromResource(legacyJSResource)
             ),
             tags = tags,
             annotations = annotations
@@ -1366,18 +1388,21 @@ class RecordServiceFetchRecordsModuleTest {
             PARTNER_ID
         )
 
-        val resource = SdkFhirParser.toFhir4(
+        val resource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val legacyKMPResource = SdkFhirParser.toFhir4(
+        val legacyKMPResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template2
         ) as Fhir4DocumentReference
 
-        val legacyJSResource = SdkFhirParser.toFhir4(
+        val legacyJSResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template3
         ) as Fhir4DocumentReference
 
@@ -1386,9 +1411,9 @@ class RecordServiceFetchRecordsModuleTest {
 
         runFhirBatchFlow(
             serializedResources = Triple(
-                SdkFhirParser.fromResource(resource)!!,
-                SdkFhirParser.fromResource(legacyKMPResource)!!,
-                SdkFhirParser.fromResource(legacyJSResource)!!,
+                SdkFhirParser.fromResource(resource),
+                SdkFhirParser.fromResource(legacyKMPResource),
+                SdkFhirParser.fromResource(legacyJSResource),
             ),
             tags = tags,
             annotations = annotations,

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceModuleTestFlowHelper.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceModuleTestFlowHelper.kt
@@ -404,25 +404,7 @@ class RecordServiceModuleTestFlowHelper(
         keys
     )
 
-    private fun buildEncryptedRecordWithEncodedBody(
-        id: String?,
-        commonKeyId: String,
-        tags: List<String>,
-        annotations: Annotations,
-        body: String,
-        dates: Pair<String?, String?>,
-        keys: Pair<EncryptedKey, EncryptedKey?>
-    ): EncryptedRecord = createEncryptedRecord(
-        id,
-        commonKeyId,
-        tags,
-        annotations,
-        Base64.encodeToString(md5(body)),
-        dates,
-        keys
-    )
-
-    fun prepareEncryptedFhirRecord(
+    fun prepareEncryptedRecord(
         recordId: String?,
         resource: String,
         tags: List<String>,
@@ -433,26 +415,6 @@ class RecordServiceModuleTestFlowHelper(
         creationDate: String,
         updateDate: String?
     ): EncryptedRecord = buildEncryptedRecord(
-        recordId,
-        commonKeyId,
-        tags,
-        annotations,
-        resource,
-        Pair(creationDate, updateDate),
-        Pair(encryptedDataKey, encryptedAttachmentsKey)
-    )
-
-    fun prepareEncryptedDataRecord(
-        recordId: String?,
-        resource: String,
-        tags: List<String>,
-        annotations: Annotations,
-        commonKeyId: String,
-        encryptedDataKey: EncryptedKey,
-        encryptedAttachmentsKey: EncryptedKey?,
-        creationDate: String,
-        updateDate: String?
-    ): EncryptedRecord = buildEncryptedRecordWithEncodedBody(
         recordId,
         commonKeyId,
         tags,

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceUpdateRecordModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceUpdateRecordModuleTest.kt
@@ -26,7 +26,10 @@ import care.data4life.sdk.config.DataRestrictionException
 import care.data4life.sdk.crypto.CryptoContract
 import care.data4life.sdk.data.DataResource
 import care.data4life.sdk.fhir.Fhir3Identifier
+import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Identifier
+import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.fhir.ResourceCryptoService
 import care.data4life.sdk.model.Record
 import care.data4life.sdk.network.NetworkingContract
@@ -472,21 +475,23 @@ class RecordServiceUpdateRecordModuleTest {
 
         val now = SdkDateTimeFormatter.now()
 
-        val resourceNew = SdkFhirParser.toFhir3(
+        val resourceNew = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir3(
+        val resourceOld = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         resourceOld.description = "A outdated mock"
 
         runFhirFlow(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(resourceNew)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(resourceNew),
             tags = tags,
             updateDates = Pair(now, UPDATE_DATE)
         )
@@ -539,21 +544,23 @@ class RecordServiceUpdateRecordModuleTest {
             PARTNER_ID
         )
 
-        val resourceNew = SdkFhirParser.toFhir3(
+        val resourceNew = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir3(
+        val resourceOld = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         resourceOld.description = "A outdated mock"
 
         runFhirFlow(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(resourceNew)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(resourceNew),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE)
@@ -617,18 +624,21 @@ class RecordServiceUpdateRecordModuleTest {
             "d4l_f_p_t#$ATTACHMENT_ID#$PREVIEW_ID#$THUMBNAIL_ID"
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir3(
+        val resourceNew = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir3(
+        val resourceOld = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -662,8 +672,8 @@ class RecordServiceUpdateRecordModuleTest {
         internalResource.content[0].attachment.data = null
 
         runFhirFlowWithAttachment(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE),
@@ -743,18 +753,21 @@ class RecordServiceUpdateRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir3(
+        val resourceNew = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir3(
+        val resourceOld = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
@@ -776,8 +789,8 @@ class RecordServiceUpdateRecordModuleTest {
         val thumbnail = Pair(ByteArray(1), THUMBNAIL_ID)
 
         runFhirFlowWithAttachment(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE),
@@ -859,24 +872,27 @@ class RecordServiceUpdateRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir3(
+        val resourceNew = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir3(
+        val resourceOld = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         runFhirFlowWithAttachment(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE),
@@ -923,26 +939,29 @@ class RecordServiceUpdateRecordModuleTest {
             PARTNER_ID
         )
 
-        val internalResource = SdkFhirParser.toFhir3(
+        val internalResource = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir3(
+        val resourceNew = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir3(
+        val resourceOld = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         resourceOld.description = "A outdated mock"
 
         runFhirFlow(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE)
@@ -1010,21 +1029,23 @@ class RecordServiceUpdateRecordModuleTest {
 
         val now = SdkDateTimeFormatter.now()
 
-        val resourceNew = SdkFhirParser.toFhir4(
+        val resourceNew = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir4(
+        val resourceOld = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         resourceOld.description = "A outdated mock"
 
         runFhirFlow(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(resourceNew)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(resourceNew),
             tags = tags,
             updateDates = Pair(now, UPDATE_DATE)
         )
@@ -1077,21 +1098,23 @@ class RecordServiceUpdateRecordModuleTest {
             PARTNER_ID
         )
 
-        val resourceNew = SdkFhirParser.toFhir4(
+        val resourceNew = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir4(
+        val resourceOld = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         resourceOld.description = "A outdated mock"
 
         runFhirFlow(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(resourceNew)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(resourceNew),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE)
@@ -1155,18 +1178,21 @@ class RecordServiceUpdateRecordModuleTest {
             "d4l_f_p_t#$ATTACHMENT_ID#$PREVIEW_ID#$THUMBNAIL_ID"
         )
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir4(
+        val resourceNew = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir4(
+        val resourceOld = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
@@ -1200,8 +1226,8 @@ class RecordServiceUpdateRecordModuleTest {
         internalResource.content[0].attachment.data = null
 
         runFhirFlowWithAttachment(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE),
@@ -1281,18 +1307,21 @@ class RecordServiceUpdateRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir4(
+        val resourceNew = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir4(
+        val resourceOld = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
@@ -1314,8 +1343,8 @@ class RecordServiceUpdateRecordModuleTest {
         val thumbnail = Pair(ByteArray(1), THUMBNAIL_ID)
 
         runFhirFlowWithAttachment(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE),
@@ -1397,24 +1426,27 @@ class RecordServiceUpdateRecordModuleTest {
             attachment
         )
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir4(
+        val resourceNew = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir4(
+        val resourceOld = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         runFhirFlowWithAttachment(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE),
@@ -1555,21 +1587,23 @@ class RecordServiceUpdateRecordModuleTest {
             PARTNER_ID
         )
 
-        val resourceNew = SdkFhirParser.toFhir4(
+        val resourceNew = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir3(
+        val resourceOld = SdkFhirParser.toFhir<Fhir3Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_3.version,
             template
         ) as Fhir3DocumentReference
 
         resourceOld.description = "A outdated mock"
 
         runFhirFlow(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(resourceNew)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(resourceNew),
             tags = tags,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE),
             oldTags = oldTags
@@ -1614,26 +1648,29 @@ class RecordServiceUpdateRecordModuleTest {
             PARTNER_ID
         )
 
-        val internalResource = SdkFhirParser.toFhir4(
+        val internalResource = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceNew = SdkFhirParser.toFhir4(
+        val resourceNew = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
-        val resourceOld = SdkFhirParser.toFhir4(
+        val resourceOld = SdkFhirParser.toFhir<Fhir4Resource>(
             resourceType,
+            FhirContract.FhirVersion.FHIR_4.version,
             template
         ) as Fhir4DocumentReference
 
         resourceOld.description = "A outdated mock"
 
         runFhirFlow(
-            serializedResourceOld = SdkFhirParser.fromResource(resourceOld)!!,
-            serializedResourceNew = SdkFhirParser.fromResource(internalResource)!!,
+            serializedResourceOld = SdkFhirParser.fromResource(resourceOld),
+            serializedResourceNew = SdkFhirParser.fromResource(internalResource),
             tags = tags,
             annotations = annotations,
             updateDates = Pair(SdkDateTimeFormatter.now(), UPDATE_DATE)

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceUpdateRecordModuleTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceUpdateRecordModuleTest.kt
@@ -275,7 +275,7 @@ class RecordServiceUpdateRecordModuleTest {
         val (encodedTags, allTags) = mergeTags(tags, oldTags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedUploadRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedUploadRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResourceOld,
             encodedTags,
@@ -287,7 +287,7 @@ class RecordServiceUpdateRecordModuleTest {
             updateDates.first
         )
 
-        val encryptedReceivedRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedReceivedRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResourceNew,
             encodedTags,
@@ -339,7 +339,7 @@ class RecordServiceUpdateRecordModuleTest {
         val encodedTags = flowHelper.prepareTags(tags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedUploadRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedUploadRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResourceOld,
             encodedTags,
@@ -351,7 +351,7 @@ class RecordServiceUpdateRecordModuleTest {
             updateDates.first
         )
 
-        val encryptedReceivedRecord = flowHelper.prepareEncryptedFhirRecord(
+        val encryptedReceivedRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResourceNew,
             encodedTags,
@@ -409,7 +409,7 @@ class RecordServiceUpdateRecordModuleTest {
         val encodedTags = flowHelper.prepareTags(tags)
         val encodedAnnotations = flowHelper.prepareAnnotations(annotations)
 
-        val encryptedUploadRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedUploadRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResourceOld,
             encodedTags,
@@ -421,7 +421,7 @@ class RecordServiceUpdateRecordModuleTest {
             updateDates.first
         )
 
-        val encryptedReceivedRecord = flowHelper.prepareEncryptedDataRecord(
+        val encryptedReceivedRecord = flowHelper.prepareEncryptedRecord(
             recordId,
             serializedResourceNew,
             encodedTags,

--- a/sdk-core/src/test/java/care/data4life/sdk/fhir/ResourceCryptoServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/fhir/ResourceCryptoServiceTest.kt
@@ -30,9 +30,6 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.reactivex.Single
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertSame
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -76,14 +73,14 @@ class ResourceCryptoServiceTest {
         every { SdkFhirParser.fromResource(any()) } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.EncryptionFailed> {
             // When
             resourceCryptoService.encryptResource(dataKey, resource)
         }
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$EncryptionFailed: Failed to encrypt resource"
+            expected = "Failed to encrypt resource"
         )
     }
 
@@ -98,14 +95,14 @@ class ResourceCryptoServiceTest {
         every { cryptoService.encryptAndEncodeString(dataKey, any()) } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.EncryptionFailed> {
             // When
             resourceCryptoService.encryptResource(dataKey, resource)
         }
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$EncryptionFailed: Failed to encrypt resource"
+            expected = "Failed to encrypt resource"
         )
     }
 
@@ -143,14 +140,14 @@ class ResourceCryptoServiceTest {
         every { SdkFhirParser.fromResource(any()) } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.EncryptionFailed> {
             // When
             resourceCryptoService.encryptResource(dataKey, resource)
         }
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$EncryptionFailed: Failed to encrypt resource"
+            expected = "Failed to encrypt resource"
         )
     }
 
@@ -165,14 +162,14 @@ class ResourceCryptoServiceTest {
         every { cryptoService.encryptAndEncodeString(dataKey, any()) } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.EncryptionFailed> {
             // When
             resourceCryptoService.encryptResource(dataKey, resource)
         }
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$EncryptionFailed: Failed to encrypt resource"
+            expected = "Failed to encrypt resource"
         )
     }
 
@@ -257,7 +254,7 @@ class ResourceCryptoServiceTest {
         )
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.DecryptionFailed> {
             // When
             resourceCryptoService.decryptResource<Fhir3Resource>(
                 dataKey,
@@ -268,7 +265,7 @@ class ResourceCryptoServiceTest {
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$DecryptionFailed: Failed to decrypt resource"
+            expected = "Failed to decrypt resource"
         )
     }
 
@@ -286,7 +283,7 @@ class ResourceCryptoServiceTest {
         every { cryptoService.decodeAndDecryptString(dataKey, encryptedResource) } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.DecryptionFailed> {
             // When
             resourceCryptoService.decryptResource<Fhir3Resource>(
                 dataKey,
@@ -297,7 +294,7 @@ class ResourceCryptoServiceTest {
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$DecryptionFailed: Failed to decrypt resource"
+            expected = "Failed to decrypt resource"
         )
     }
 
@@ -328,7 +325,7 @@ class ResourceCryptoServiceTest {
         } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.DecryptionFailed> {
             // When
             resourceCryptoService.decryptResource<Fhir3Resource>(
                 dataKey,
@@ -339,7 +336,7 @@ class ResourceCryptoServiceTest {
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$DecryptionFailed: Failed to decrypt resource"
+            expected = "Failed to decrypt resource"
         )
     }
 
@@ -394,7 +391,7 @@ class ResourceCryptoServiceTest {
         )
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.DecryptionFailed> {
             // When
             resourceCryptoService.decryptResource<Fhir4Resource>(
                 dataKey,
@@ -405,7 +402,7 @@ class ResourceCryptoServiceTest {
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$DecryptionFailed: Failed to decrypt resource"
+            expected = "Failed to decrypt resource"
         )
     }
 
@@ -423,7 +420,7 @@ class ResourceCryptoServiceTest {
         every { cryptoService.decodeAndDecryptString(dataKey, encryptedResource) } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.DecryptionFailed> {
             // When
             resourceCryptoService.decryptResource<Fhir4Resource>(
                 dataKey,
@@ -434,7 +431,7 @@ class ResourceCryptoServiceTest {
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$DecryptionFailed: Failed to decrypt resource"
+            expected = "Failed to decrypt resource"
         )
     }
 
@@ -465,7 +462,7 @@ class ResourceCryptoServiceTest {
         } throws exception
 
         // Then
-        val error = assertFailsWith<RuntimeException> {
+        val error = assertFailsWith<CryptoException.DecryptionFailed> {
             // When
             resourceCryptoService.decryptResource<Fhir4Resource>(
                 dataKey,
@@ -476,7 +473,7 @@ class ResourceCryptoServiceTest {
 
         assertEquals(
             actual = error.message,
-            expected = "care.data4life.crypto.error.CryptoException\$DecryptionFailed: Failed to decrypt resource"
+            expected = "Failed to decrypt resource"
         )
     }
 
@@ -545,6 +542,7 @@ class ResourceCryptoServiceTest {
         )
     }
 
+    @Test
     fun `Given, decryptResource is called with a encrypted DataResource, Tags and DataKey, it propagates CryptoService Errors`() {
         // Given
         val exception = RuntimeException("Happy failure")

--- a/sdk-core/src/test/java/care/data4life/sdk/fhir/ResourceCryptoServiceTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/fhir/ResourceCryptoServiceTest.kt
@@ -318,8 +318,9 @@ class ResourceCryptoServiceTest {
         } returns Single.just(serializedResource)
 
         every {
-            SdkFhirParser.toFhir3(
+            SdkFhirParser.toFhir<Fhir3Resource>(
                 tags[TAG_RESOURCE_TYPE]!!,
+                tags[TAG_FHIR_VERSION]!!,
                 serializedResource
             )
         } throws exception
@@ -360,8 +361,9 @@ class ResourceCryptoServiceTest {
         } returns Single.just(serializedResource)
 
         every {
-            SdkFhirParser.toFhir3(
+            SdkFhirParser.toFhir<Fhir3Resource>(
                 tags[TAG_RESOURCE_TYPE]!!,
+                tags[TAG_FHIR_VERSION]!!,
                 serializedResource
             )
         } returns resource
@@ -455,8 +457,9 @@ class ResourceCryptoServiceTest {
         } returns Single.just(serializedResource)
 
         every {
-            SdkFhirParser.toFhir4(
+            SdkFhirParser.toFhir<Fhir4Resource>(
                 tags[TAG_RESOURCE_TYPE]!!,
+                tags[TAG_FHIR_VERSION]!!,
                 serializedResource
             )
         } throws exception
@@ -497,8 +500,9 @@ class ResourceCryptoServiceTest {
         } returns Single.just(serializedResource)
 
         every {
-            SdkFhirParser.toFhir4(
+            SdkFhirParser.toFhir<Fhir4Resource>(
                 tags[TAG_RESOURCE_TYPE]!!,
+                tags[TAG_FHIR_VERSION]!!,
                 serializedResource
             )
         } returns resource

--- a/sdk-core/src/test/java/care/data4life/sdk/network/model/RecordCryptoServiceEncryptionTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/network/model/RecordCryptoServiceEncryptionTest.kt
@@ -107,7 +107,7 @@ class RecordCryptoServiceEncryptionTest {
         every { decryptedRecord.attachmentsKey } returns attachmentKey
         every { decryptedRecord.resource } returns resource
 
-        every { resourceCryptoService._encryptResource(dataKey, resource) } returns encryptedResource
+        every { resourceCryptoService.encryptResource(dataKey, resource) } returns encryptedResource
 
         every {
             cryptoService.encryptSymmetricKey(
@@ -317,7 +317,7 @@ class RecordCryptoServiceEncryptionTest {
             expected = encryptedResource
         )
 
-        verify(exactly = 1) { resourceCryptoService._encryptResource(dataKey, resource) }
+        verify(exactly = 1) { resourceCryptoService.encryptResource(dataKey, resource) }
     }
 
     @Test
@@ -602,7 +602,7 @@ class RecordCryptoServiceEncryptionTest {
             expected = encryptedResource
         )
 
-        verify(exactly = 1) { resourceCryptoService._encryptResource(dataKey, resource) }
+        verify(exactly = 1) { resourceCryptoService.encryptResource(dataKey, resource) }
     }
 
     @Test
@@ -887,7 +887,7 @@ class RecordCryptoServiceEncryptionTest {
             expected = encryptedResource
         )
 
-        verify(exactly = 1) { resourceCryptoService._encryptResource(dataKey, resource) }
+        verify(exactly = 1) { resourceCryptoService.encryptResource(dataKey, resource) }
     }
 
     @Test

--- a/sdk-core/src/test/java/care/data4life/sdk/test/fake/CryptoServiceFake.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/test/fake/CryptoServiceFake.kt
@@ -119,11 +119,7 @@ class CryptoServiceFake : CryptoContract.Service {
             Single.just(currentIteration.resources[idx].toByteArray())
         } else {
             throw RuntimeException(
-                "Unable to fake resource decryption: \nKey: $key \nData: ${
-                String(
-                    data
-                )
-                }"
+                "Unable to fake resource decryption: \nKey: $key \nData: ${String(data)}"
             )
         }
     }
@@ -131,7 +127,7 @@ class CryptoServiceFake : CryptoContract.Service {
     override fun encryptAndEncodeByteArray(
         key: GCKey,
         data: ByteArray
-    ): Single<String> = encryptAndEncodeString(key, String(data))
+    ): Single<String> = encryptAndEncodeString(key, String(data)).also { println(String(data)) }
 
     override fun encryptAndEncodeString(key: GCKey, data: String): Single<String> {
         val idx = findResource(key, data)

--- a/sdk-core/src/test/java/care/data4life/sdk/test/fake/CryptoServiceFake.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/test/fake/CryptoServiceFake.kt
@@ -120,9 +120,9 @@ class CryptoServiceFake : CryptoContract.Service {
         } else {
             throw RuntimeException(
                 "Unable to fake resource decryption: \nKey: $key \nData: ${
-                    String(
-                        data
-                    )
+                String(
+                    data
+                )
                 }"
             )
         }

--- a/sdk-core/src/test/java/care/data4life/sdk/test/fake/CryptoServiceFake.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/test/fake/CryptoServiceFake.kt
@@ -96,11 +96,7 @@ class CryptoServiceFake : CryptoContract.Service {
             Single.just(hashedResources[idx].toByteArray())
         } else {
             throw RuntimeException(
-                "Unable to fake resource encryption: \nKey: $key \nData: ${
-                String(
-                    data
-                )
-                }"
+                "Unable to fake resource encryption: \nKey: $key \nData: ${String(data)}"
             )
         }
     }
@@ -124,13 +120,18 @@ class CryptoServiceFake : CryptoContract.Service {
         } else {
             throw RuntimeException(
                 "Unable to fake resource decryption: \nKey: $key \nData: ${
-                String(
-                    data
-                )
+                    String(
+                        data
+                    )
                 }"
             )
         }
     }
+
+    override fun encryptAndEncodeByteArray(
+        key: GCKey,
+        data: ByteArray
+    ): Single<String> = encryptAndEncodeString(key, String(data))
 
     override fun encryptAndEncodeString(key: GCKey, data: String): Single<String> {
         val idx = findResource(key, data)
@@ -141,6 +142,14 @@ class CryptoServiceFake : CryptoContract.Service {
                 "Unable to fake resource encryptAndEncodeString: \nKey: $key \nData: $data"
             )
         }
+    }
+
+    override fun decodeAndDecryptByteArray(
+        key: GCKey,
+        dataBase64: String
+    ): Single<ByteArray> {
+        return decodeAndDecryptString(key, dataBase64)
+            .map { string -> string.toByteArray() }
     }
 
     override fun decodeAndDecryptString(key: GCKey, dataBase64: String): Single<String> {

--- a/sdk-core/src/test/java/care/data4life/sdk/wrapper/FhirParserTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/wrapper/FhirParserTest.kt
@@ -18,6 +18,7 @@ package care.data4life.sdk.wrapper
 
 import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Resource
+import care.data4life.sdk.fhir.FhirContract
 import care.data4life.sdk.lang.CoreRuntimeException
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -25,7 +26,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class FhirParserTest {
-
     @Test
     fun `It fulfils ResourceParser`() {
         val parser: Any = SdkFhirParser
@@ -33,27 +33,43 @@ class FhirParserTest {
     }
 
     @Test
-    fun `Given, toFhir3 is called with a ResourceType and a Source, it returns a Resource`() {
+    fun `Given, toFhir is called with a ResourceType, a unknown version and a Source, it fails`() {
+        assertFailsWith<CoreRuntimeException.UnsupportedOperation> {
+            SdkFhirParser.toFhir("type", "unknown", "resource")
+        }
+    }
+
+    @Test
+    fun `Given, toFhir is called with a ResourceType, a Fhir3 version and a Source, it returns a Fhir3Resource`() {
         // Given
         val type = "DocumentReference"
-        val source = "{\"resourceType\":\"DomainResource\"}"
+        val source = "{\"resourceType\":\"DocumentReference\"}"
 
         // When
-        val resource: Any = SdkFhirParser.toFhir3(type, source)
+        val resource: Any = SdkFhirParser.toFhir(
+            type,
+            FhirContract.FhirVersion.FHIR_3.version,
+            source
+        )
 
         // Then
         assertTrue(resource is Fhir3Resource)
     }
 
     @Test
-    fun `Given, toFhir4 is called with a ResourceType and a Source, it returns a Resource`() {
+    fun `Given, toFhir is called with a ResourceType, a Fhir4 version and a Source, it returns a Fhir4Resource`() {
         // Given
         val type = "DocumentReference"
         val source = "{\"resourceType\":\"DomainResource\"}"
 
         // When
-        val resource: Any = SdkFhirParser.toFhir4(type, source)
+        val resource: Any = SdkFhirParser.toFhir(
+            type,
+            FhirContract.FhirVersion.FHIR_4.version,
+            source
+        )
 
+        // Then
         assertTrue(resource is Fhir4Resource)
     }
 

--- a/sdk-core/src/test/java/care/data4life/sdk/wrapper/FhirParserTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/wrapper/FhirParserTest.kt
@@ -45,7 +45,7 @@ class FhirParserTest {
         assertTrue(resource is Fhir3Resource)
     }
 
-    @Test // Test is working, but the Constructor Mock causes flakyness
+    @Test
     fun `Given, toFhir4 is called with a ResourceType and a Source, it returns a Resource`() {
         // Given
         val type = "DocumentReference"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a refactoring of the ResourceCryptoService. It gets rid of JavaRx and aligns the handling of the current resource types.
Also errors during the de-/encryption are now correctly propagated as D4LExceptions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a need to pull out JavaRx completely out of the SDK since it aims for KMP. Also the current implementation does something, which belongs in another place.
This is part of [SDK-574](https://gesundheitscloud.atlassian.net/browse/SDK-574)

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
As stated it removes JavaRx and dries out structural patterns in terms of the resource en-/decryption.
This is part of [SDK-574](https://gesundheitscloud.atlassian.net/browse/SDK-574) and depends on #153.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All new cases had been covered by unittests. Also the module tests needed alignment in terms of the resource encryption.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
