### PR TITLE
[SDK-575] Bump JaCoCo 0.8.3 -> 0.8.7

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,7 @@ toc::[]
 
 === Bumped
 
+* JaCoCo 0.8.3 -> 0.8.7
 * mockk 1.10.0 -> 1.10.6
 
 === Migration

--- a/auth-jvm/build.gradle.kts
+++ b/auth-jvm/build.gradle.kts
@@ -57,6 +57,12 @@ dependencies {
 
 tasks.jacocoTestReport {
     reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
         html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/auth-jvm/build.gradle.kts
+++ b/auth-jvm/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
     id("kotlin-platform-jvm")
     id("java-library")
     kotlin("kapt")
-    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco.gradle.kts")

--- a/auth-jvm/build.gradle.kts
+++ b/auth-jvm/build.gradle.kts
@@ -54,15 +54,3 @@ dependencies {
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvmJunit)
     testImplementation(Dependencies.Multiplatform.Test.MockK.jdk)
 }
-
-tasks.jacocoTestReport {
-    reports {
-        html.isEnabled = true
-        xml.isEnabled = true
-        csv.isEnabled = true
-
-        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
-        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
-        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
-    }
-}

--- a/auth-jvm/build.gradle.kts
+++ b/auth-jvm/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("kotlin-platform-jvm")
     id("java-library")
     kotlin("kapt")
+    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco.gradle.kts")
@@ -52,4 +53,10 @@ dependencies {
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvm)
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvmJunit)
     testImplementation(Dependencies.Multiplatform.Test.MockK.jdk)
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+    }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -68,7 +68,7 @@ object Versions {
 
     // Java
     const val javaXAnnotation = "3.0.2"
-    const val jacocoVersion = "0.8.3"
+    const val jacocoVersion = "0.8.7"
 
     // Android
     const val androidDesugar = "1.0.5"

--- a/crypto-jvm/build.gradle.kts
+++ b/crypto-jvm/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("kotlin-platform-jvm")
     id("java-library")
     kotlin("kapt")
+    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
@@ -45,4 +46,10 @@ dependencies {
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvm)
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvmJunit)
     testImplementation(Dependencies.Multiplatform.Test.MockK.jdk)
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+    }
 }

--- a/crypto-jvm/build.gradle.kts
+++ b/crypto-jvm/build.gradle.kts
@@ -50,6 +50,12 @@ dependencies {
 
 tasks.jacocoTestReport {
     reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
         html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/crypto-jvm/build.gradle.kts
+++ b/crypto-jvm/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
     id("kotlin-platform-jvm")
     id("java-library")
     kotlin("kapt")
-    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")

--- a/crypto-jvm/build.gradle.kts
+++ b/crypto-jvm/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     id("jacoco")
 }
 
-apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
+apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")
 apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 java {
@@ -46,16 +46,4 @@ dependencies {
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvm)
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvmJunit)
     testImplementation(Dependencies.Multiplatform.Test.MockK.jdk)
-}
-
-tasks.jacocoTestReport {
-    reports {
-        html.isEnabled = true
-        xml.isEnabled = true
-        csv.isEnabled = true
-
-        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
-        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
-        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
-    }
 }

--- a/gradle/jacoco-java.gradle.kts
+++ b/gradle/jacoco-java.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 D4L data4life gGmbH / All rights reserved.
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
  *
  * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
  * including any intellectual property rights that subsist in the SDK.
@@ -13,20 +13,24 @@
  * applications and/or if you’d like to contribute to the development of the SDK, please
  * contact D4L by email to help@data4life.care.
  */
+apply(plugin = "jacoco")
 
-apply plugin: 'jacoco'
-
-test {
+tasks.named<Test>("test") {
     testLogging {
-        events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
+        events("passed", "skipped", "failed", "standardOut", "standardError")
     }
 }
 
-jacocoTestReport {
+tasks.named<JacocoReport>("jacocoTestReport") {
+    dependsOn(tasks.named("test"))
+
     reports {
-        xml.enabled true
-        csv.enabled false
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }
-
-jacocoTestReport.dependsOn('test')

--- a/sample-jvm/build.gradle.kts
+++ b/sample-jvm/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("jacoco")
 }
 
-apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
+apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")
 
 val d4lClientConfig = D4LConfigHelper.loadClientConfigAndroid("$rootDir")
 val d4LTestConfig = D4LConfigHelper.loadTestConfigAndroid("$rootDir")
@@ -92,17 +92,5 @@ tasks.named("clean") {
     doLast {
         delete("${androidTestAssetsPath}/client_config.json")
         delete("${assetsPath}/client_config.json")
-    }
-}
-
-tasks.jacocoTestReport {
-    reports {
-        html.isEnabled = true
-        xml.isEnabled = true
-        csv.isEnabled = true
-
-        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
-        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
-        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sample-jvm/build.gradle.kts
+++ b/sample-jvm/build.gradle.kts
@@ -97,6 +97,12 @@ tasks.named("clean") {
 
 tasks.jacocoTestReport {
     reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
         html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sample-jvm/build.gradle.kts
+++ b/sample-jvm/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
     id("application")
 
     id("com.github.johnrengelman.shadow") version "5.2.0"
-    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")

--- a/sample-jvm/build.gradle.kts
+++ b/sample-jvm/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     id("application")
 
     id("com.github.johnrengelman.shadow") version "5.2.0"
+    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
@@ -91,5 +92,11 @@ tasks.named("clean") {
     doLast {
         delete("${androidTestAssetsPath}/client_config.json")
         delete("${assetsPath}/client_config.json")
+    }
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
     }
 }

--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
     id("java-library")
     id("kotlin")
     kotlin("kapt")
-    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")

--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -117,6 +117,12 @@ tasks.named("clean") {
 
 tasks.jacocoTestReport {
     reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
         html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     id("java-library")
     id("kotlin")
     kotlin("kapt")
+    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
@@ -111,5 +112,11 @@ tasks.named("compileKotlin") {
 tasks.named("clean") {
     doLast {
         delete("${configPath}/SDKConfig.kt")
+    }
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
     }
 }

--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("jacoco")
 }
 
-apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
+apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")
 apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 group = LibraryConfig.group
@@ -112,17 +112,5 @@ tasks.named("compileKotlin") {
 tasks.named("clean") {
     doLast {
         delete("${configPath}/SDKConfig.kt")
-    }
-}
-
-tasks.jacocoTestReport {
-    reports {
-        html.isEnabled = true
-        xml.isEnabled = true
-        csv.isEnabled = true
-
-        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
-        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
-        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sdk-ingestion/build.gradle.kts
+++ b/sdk-ingestion/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     id("maven-publish")
     id("kotlin")
     kotlin("kapt")
+    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
@@ -78,5 +79,11 @@ dependencies {
 tasks {
     named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
         exclude("bcprov-jdk15on-1.64.jar")
+    }
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
     }
 }

--- a/sdk-ingestion/build.gradle.kts
+++ b/sdk-ingestion/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("jacoco")
 }
 
-apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
+apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")
 apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 
@@ -79,17 +79,5 @@ dependencies {
 tasks {
     named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
         exclude("bcprov-jdk15on-1.64.jar")
-    }
-}
-
-tasks.jacocoTestReport {
-    reports {
-        html.isEnabled = true
-        xml.isEnabled = true
-        csv.isEnabled = true
-
-        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
-        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
-        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sdk-ingestion/build.gradle.kts
+++ b/sdk-ingestion/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
     id("maven-publish")
     id("kotlin")
     kotlin("kapt")
-    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")

--- a/sdk-ingestion/build.gradle.kts
+++ b/sdk-ingestion/build.gradle.kts
@@ -84,6 +84,12 @@ tasks {
 
 tasks.jacocoTestReport {
     reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
         html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sdk-jvm/build.gradle.kts
+++ b/sdk-jvm/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     id("jacoco")
 }
 
-apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
+apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")
 apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 
@@ -62,17 +62,5 @@ dependencies {
 tasks {
     named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
         exclude("bcprov-jdk15on-1.64.jar")
-    }
-}
-
-tasks.jacocoTestReport {
-    reports {
-        html.isEnabled = true
-        xml.isEnabled = true
-        csv.isEnabled = true
-
-        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
-        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
-        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sdk-jvm/build.gradle.kts
+++ b/sdk-jvm/build.gradle.kts
@@ -67,6 +67,12 @@ tasks {
 
 tasks.jacocoTestReport {
     reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
         html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/sdk-jvm/build.gradle.kts
+++ b/sdk-jvm/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "4.0.1"
     id("java-library")
     id("maven-publish")
+    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
@@ -61,5 +62,11 @@ dependencies {
 tasks {
     named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
         exclude("bcprov-jdk15on-1.64.jar")
+    }
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
     }
 }

--- a/sdk-jvm/build.gradle.kts
+++ b/sdk-jvm/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
     id("com.github.johnrengelman.shadow") version "4.0.1"
     id("java-library")
     id("maven-publish")
-    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")

--- a/securestore-jvm/build.gradle.kts
+++ b/securestore-jvm/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("jacoco")
 }
 
-apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
+apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")
 apply(from = "${project.rootDir}/gradle/deploy-java.gradle")
 
 
@@ -50,16 +50,4 @@ dependencies {
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvm)
     testImplementation(Dependencies.Multiplatform.Test.Kotlin.testJvmJunit)
     testImplementation(Dependencies.Multiplatform.Test.MockK.jdk)
-}
-
-tasks.jacocoTestReport {
-    reports {
-        html.isEnabled = true
-        xml.isEnabled = true
-        csv.isEnabled = true
-
-        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
-        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
-        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
-    }
 }

--- a/securestore-jvm/build.gradle.kts
+++ b/securestore-jvm/build.gradle.kts
@@ -54,6 +54,12 @@ dependencies {
 
 tasks.jacocoTestReport {
     reports {
+        html.isEnabled = true
+        xml.isEnabled = true
+        csv.isEnabled = true
+
         html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+        csv.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.csv").get().asFile
+        xml.destination = layout.buildDirectory.file("reports/jacoco/test/${project.name}.xml").get().asFile
     }
 }

--- a/securestore-jvm/build.gradle.kts
+++ b/securestore-jvm/build.gradle.kts
@@ -17,7 +17,6 @@
 plugins {
     id("java-library")
     id("kotlin-platform-jvm")
-    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle.kts")

--- a/securestore-jvm/build.gradle.kts
+++ b/securestore-jvm/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     id("java-library")
     id("kotlin-platform-jvm")
+    id("jacoco")
 }
 
 apply(from = "${project.rootDir}/gradle/jacoco-java.gradle")
@@ -51,4 +52,8 @@ dependencies {
     testImplementation(Dependencies.Multiplatform.Test.MockK.jdk)
 }
 
-
+tasks.jacocoTestReport {
+    reports {
+        html.destination = layout.buildDirectory.dir("reports/jacoco/test/${project.name}").get().asFile
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This updates and fixes the HTML generation of JaCoCo.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JaCoCo 0.8.3 is already 2 years old and the currently HTML, XML and CSV generation is broken.
This is part of [SDK-575](https://gesundheitscloud.atlassian.net/browse/SDK-575).

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
It bumps the JaCoCo version and adds specifies for each module a custom report directory for HTML and custom file names for the other formats to avoid overwriting the already generated files.
In order to achieve this, the gradle script had been moved to kotlin script.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This can only be verified locally by running `./gradlew clean && ./gradlew jacocoTestReport`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
