### PR TITLE
Fix update failing for PDF files because of missing preview

### DIFF
--- a/.github/workflows/d4l-ci-pull-request-validation.yml
+++ b/.github/workflows/d4l-ci-pull-request-validation.yml
@@ -2,7 +2,7 @@ name: D4L CI - Pull-Request Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, edited, reopened]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - release/*

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,8 @@ toc::[]
 
 === Fixed
 
+- Fix update failing for PDF files because of missing preview
+
 === Bumped
 
 === Migration

--- a/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/RecordService.kt
@@ -60,6 +60,7 @@ import care.data4life.sdk.network.model.RecordCryptoService
 import care.data4life.sdk.record.RecordContract
 import care.data4life.sdk.record.RecordContract.Service.Companion.DOWNSCALED_ATTACHMENT_IDS_FMT
 import care.data4life.sdk.record.RecordContract.Service.Companion.DOWNSCALED_ATTACHMENT_IDS_SIZE
+import care.data4life.sdk.record.RecordContract.Service.Companion.DOWNSCALED_ATTACHMENT_IDS_SIZE_WITHOUT_PREVIEW
 import care.data4life.sdk.record.RecordContract.Service.Companion.EMPTY_RECORD_ID
 import care.data4life.sdk.record.RecordContract.Service.Companion.FULL_ATTACHMENT_ID_POS
 import care.data4life.sdk.record.RecordContract.Service.Companion.PREVIEW_ID_POS
@@ -1151,7 +1152,7 @@ class RecordService internal constructor(
         }
         val parts = identifier.value!!.split(ThumbnailService.SPLIT_CHAR.toRegex())
 
-        if (parts.size != DOWNSCALED_ATTACHMENT_IDS_SIZE) {
+        if (parts.size != DOWNSCALED_ATTACHMENT_IDS_SIZE && parts.size != DOWNSCALED_ATTACHMENT_IDS_SIZE_WITHOUT_PREVIEW) {
             throw DataValidationException.IdUsageViolation(identifier.value)
         }
         return parts

--- a/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
+++ b/sdk-core/src/main/java/care/data4life/sdk/record/RecordContract.kt
@@ -185,6 +185,7 @@ interface RecordContract {
             // d4l -> namespace, f-> full, p -> preview, t -> thumbnail
             const val DOWNSCALED_ATTACHMENT_IDS_FMT = "d4l_f_p_t"
             const val DOWNSCALED_ATTACHMENT_IDS_SIZE = 4
+            const val DOWNSCALED_ATTACHMENT_IDS_SIZE_WITHOUT_PREVIEW = 2
             const val FULL_ATTACHMENT_ID_POS = 1
             const val PREVIEW_ID_POS = 2
             const val THUMBNAIL_ID_POS = 3

--- a/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
+++ b/sdk-core/src/test/java/care/data4life/sdk/RecordServiceAttachmentIdentifierUtilsTest.kt
@@ -32,6 +32,7 @@ import care.data4life.sdk.lang.DataValidationException
 import care.data4life.sdk.model.DownloadType
 import care.data4life.sdk.network.NetworkingContract
 import care.data4life.sdk.record.RecordContract.Service.Companion.DOWNSCALED_ATTACHMENT_IDS_FMT
+import care.data4life.sdk.record.RecordContract.Service.Companion.DOWNSCALED_ATTACHMENT_IDS_SIZE_WITHOUT_PREVIEW
 import care.data4life.sdk.record.RecordContract.Service.Companion.PREVIEW_ID_POS
 import care.data4life.sdk.record.RecordContract.Service.Companion.THUMBNAIL_ID_POS
 import care.data4life.sdk.tag.TaggingContract
@@ -168,6 +169,24 @@ class RecordServiceAttachmentIdentifierUtilsTest {
         assertEquals(
             actual = parts,
             expected = value
+        )
+    }
+
+    @Test
+    fun `Given, splitAdditionalAttachmentId is called, with a shortend WrappedIdentifier, it succeeds, if the parts of the Identifiers value match DOWNSCALED_ATTACHMENT_IDS_SIZE_WITHOUT_PREVIEW`() {
+        // Given
+        val identifier = "$DOWNSCALED_ATTACHMENT_IDS_FMT#ATTACHMENT_ID"
+        val additionalIdentifier: WrapperInternalContract.Identifier = mockk()
+
+        every { additionalIdentifier.value } returns identifier
+
+        // Then
+        val result = recordService.splitAdditionalAttachmentId(additionalIdentifier)
+
+        // When
+        assertEquals(
+            actual = result?.size ?: 0,
+            expected = DOWNSCALED_ATTACHMENT_IDS_SIZE_WITHOUT_PREVIEW
         )
     }
 


### PR DESCRIPTION
### :tophat: What is the goal?

Fix failing update call when an attachment with PDF content is updated. It falsely expects a preview or thumbnail to be present, which doesn't exist for PDF files.

### :unicorn: How is it being implemented?

Add an exception for to allow media files without preview or thumbnail

### :thinking: DOD Checklist

- [x] My code follows the code style and naming conventions of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
- [x] I have updated the changelog accordingly.
